### PR TITLE
Fix karma runner task

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -17,7 +17,7 @@ var gulp = require('gulp'),
 	remember = require('gulp-remember'),
 	header = require('gulp-header'),
 	globby = require('globby'),
-	karma = require('karma').server,
+	Karma = require('karma').Server,
 	liveServer = require('gulp-live-server'),
 	browserSync = require('browser-sync'),
 	compression = require('compression'),
@@ -331,11 +331,11 @@ gulp.task('clean', function() {
 });
 
 gulp.task('test', ['compile-css', 'compile-js'], function (done) {
-	karma.start({
+	new Karma({
 		configFile: path.join(__dirname, 'karma.conf.js'),
 		singleRun:  true,
 		autoWatch:  false
-	}, done);
+	}, done).start();
 });
 
 gulp.task('develop', ['watch', 'browser-sync']);


### PR DESCRIPTION
Fixed karma runner because:
```
[WARN `start` method is deprecated since 0.13. It will be removed in 0.14. Please use 
  server = new Server(config, [done])
```