### PR TITLE
Add reduceIdents option to minify-css task to prevent renaming issues

### DIFF
--- a/app/templates/gulp/minify-css.js
+++ b/app/templates/gulp/minify-css.js
@@ -7,7 +7,10 @@ module.exports = function (gulp, plugins) {
 		assets.forEach(function (asset) {
 			gulp
 				.src('public/assets/css/' + asset.name)
-				.pipe(plugins.cssnano({mergeRules: false}))
+				.pipe(plugins.cssnano({
+					mergeRules: false,
+					reduceIdents: false
+				}))
 				.pipe(plugins.rename(asset.name.replace('.css', '.min.css')))
 				.pipe(plugins.size({showFiles: true, gzip: false, title: 'CSS minified'}))
 				.pipe(plugins.size({showFiles: true, gzip: true, title: 'CSS minified'}))


### PR DESCRIPTION
Currently the `reduceIdents` flag for the CSSNano Plugin was set to true. This flag is an unsafe option (see [CSSNano Optimisations - reduceIdents](http://cssnano.co/optimisations/reduceIdents/)) and can lead to keyframe renaming issues - which we just discovered this week.
