### PR TITLE
Run `yo nitro` with boolean cli options don't work as assumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The choosen options will be stored for the next project generation.
 
 It's possible to pass in these options through the command line:
 
-    yo nitro --name=myproject --pre=less --viewExt=hbs --clientTpl
+    yo nitro --name=myproject --pre=less --viewExt=hbs --clientTpl --exampleCode --exporter=false --release=false
 
 ### Update a project
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -20,15 +20,17 @@ module.exports = class extends Generator {
 
 		this.pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
 
+		const makeBoolean = (value) => (typeof value === 'string' ? value === 'true' : value);
+
 		this.passedInOptions = {
 			name: this.options.name,
 			pre: this.options.pre,
 			js: this.options.js,
 			viewExt: this.options.viewExt,
-			clientTpl: this.options.clientTpl,
-			exampleCode: this.options.exampleCode,
-			exporter: this.options.exporter,
-			release: this.options.release,
+			clientTpl: makeBoolean(this.options.clientTpl),
+			exampleCode: makeBoolean(this.options.exampleCode),
+			exporter: makeBoolean(this.options.exporter),
+			release: makeBoolean(this.options.release),
 		};
 
 		this.option('name', {


### PR DESCRIPTION
If you run for example:
`yo nitro --name=myproject --exampleCode=false`

The step "exampleCode" is still needed.