### PR TITLE
ci: use the npm version that matches the node version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ sudo: false
 node_js:
   - '8'
   - '10'
-before_install:
-  - npm i -g npm@5.6.0
 install:
 - travis_retry npm install


### PR DESCRIPTION
Removed config for travis, which installed npm version 5.6.0.
Now Travis should always use the npm version that matches the node version.