### PR TITLE
feature(project): add docker for prod and development

### DIFF
--- a/packages/generator-nitro/generators/app/index.js
+++ b/packages/generator-nitro/generators/app/index.js
@@ -254,6 +254,8 @@ module.exports = class extends Generator {
 			'src/ui.js',
 			'src/proto.js',
 			'tests/backstop/backstop.config.js',
+			'docker-compose.yml',
+			'docker-compose-dev.yml',
 			'gulpfile.js',
 			'package.json',
 		];

--- a/packages/generator-nitro/generators/app/templates/.dockerignore
+++ b/packages/generator-nitro/generators/app/templates/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.idea
+.vscode
+dist
+node_modules
+project/docs
+project/tmp
+public/assets
+public/reports
+npm-debug.log

--- a/packages/generator-nitro/generators/app/templates/Dockerfile
+++ b/packages/generator-nitro/generators/app/templates/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:10
+
+# Backstopjs - https://hub.docker.com/r/backstopjs/backstopjs/dockerfile
+ENV \
+PHANTOMJS_VERSION=2.1.16 \
+CASPERJS_VERSION=1.1.4 \
+SLIMERJS_VERSION=1.0.0 \
+BACKSTOPJS_VERSION=3.8.5 \
+# Workaround to fix phantomjs-prebuilt installation errors
+# See https://github.com/Medium/phantomjs/issues/707
+NPM_CONFIG_UNSAFE_PERM=true
+
+# Base packages
+RUN apt-get update && \
+apt-get install -y git sudo software-properties-common
+
+RUN sudo npm install -g --unsafe-perm=true --allow-root phantomjs-prebuilt@${PHANTOMJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root casperjs@${CASPERJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root slimerjs@${SLIMERJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION}
+
+RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub && sudo apt-key add linux_signing_key.pub
+RUN sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main"
+
+RUN	apt-get -y update && \
+apt-get -y install google-chrome-stable
+
+RUN apt-get install -y firefox-esr
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+COPY .npmrc ./
+RUN npm install --ignore-optional
+
+# Bundle app source
+COPY . .
+
+# Expose and start server
+EXPOSE 8080 8081 3001
+CMD [ "npm", "start" ]

--- a/packages/generator-nitro/generators/app/templates/docker-compose-dev.yml
+++ b/packages/generator-nitro/generators/app/templates/docker-compose-dev.yml
@@ -1,0 +1,13 @@
+# docker-compose.yaml
+version: "3"
+services:
+  server:
+    build: .
+    container_name: <%= name %>_server-dev
+    command: npm start
+    ports:
+    - 8081:8081
+    - 3001:3001
+    volumes:
+    - .:/app:rw
+    - /app/node_modules

--- a/packages/generator-nitro/generators/app/templates/docker-compose.yml
+++ b/packages/generator-nitro/generators/app/templates/docker-compose.yml
@@ -1,0 +1,9 @@
+# docker-compose.yaml for production (prototype)
+version: "3"
+services:
+  server:
+    build: .
+    container_name: <%= name %>_server
+    command: npm run prod
+    ports:
+    - 8080:8080

--- a/packages/generator-nitro/generators/app/templates/package.json
+++ b/packages/generator-nitro/generators/app/templates/package.json
@@ -42,7 +42,13 @@
     "prod:build": "npm run build",
     "prod:serve": "cross-env NODE_ENV=production gulp serve",
     "start": "npm-run-all start:*",
-    "start:dev": "npm run dev"
+    "start:dev": "npm run dev",
+    "docker:update": "docker-compose build",
+    "docker:start": "npm run docker:dev:start",
+    "docker:dev:start": "docker-compose -f docker-compose-dev.yml up",
+    "docker:dev:console": "docker exec -it <%= name %>_server-dev bash",
+    "docker:dev:watch": "docker-volume-watcher -e \"*.git*\" \"*build*\" \"*dist*\"",
+    "docker:prod": "docker-compose up"
   },
   "keywords": [
     "frontend",

--- a/packages/generator-nitro/generators/app/templates/project/docs/nitro-docker.md
+++ b/packages/generator-nitro/generators/app/templates/project/docs/nitro-docker.md
@@ -1,0 +1,44 @@
+# Nitro usage with docker
+
+This feature is currently in experimental status.
+
+Of course docker must be installed.
+
+## Production mode
+
+To start in production mode (prototype server):
+
+```
+npm run docker:prod
+```
+
+## Development mode
+
+To start in development mode:
+
+```
+npm run docker:start
+```
+
+⚠ Live reload for windows only works with an additional tool:
+
+Install [docker-windows-volume-watcher](https://github.com/merofeev/docker-windows-volume-watcher)
+and run:
+
+```
+npm run docker:dev:watch
+```
+
+If you need a console to the docker image, run:
+
+```
+npm run docker:dev:console
+```
+
+## Update Docker Image
+
+If you make changes to package.json or the Dockerfile you should recreate the docker image.
+
+```
+npm run docker:update
+```

--- a/packages/generator-nitro/generators/app/templates/project/docs/nitro.md
+++ b/packages/generator-nitro/generators/app/templates/project/docs/nitro.md
@@ -65,6 +65,10 @@ set PORT=8000 && set PROXY=8001 && npm start
 set PORT=3001 && npm run prod
 ```
 
+### Usage with docker (experimental)
+
+For information on how to use Nitro with docker, please refer to [nitro-docker.md](./nitro-docker.md).
+
 ## Configuring
 
 ### Config Package

--- a/packages/generator-nitro/generators/app/templates/readme.md
+++ b/packages/generator-nitro/generators/app/templates/readme.md
@@ -19,6 +19,10 @@ and start in development mode
 npm start
 ```
 
+# Usage with docker (experimental)
+
+For information on how to use Nitro with docker, please refer to [nitro-docker.md](./project/docs/nitro-docker.md) .
+
 ## Nitro
 
 For information on how to use Nitro, please refer to [nitro.md](./project/docs/nitro.md) .

--- a/packages/project-nitro/.dockerignore
+++ b/packages/project-nitro/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.idea
+.vscode
+dist
+node_modules
+project/docs
+project/tmp
+public/assets
+public/reports
+npm-debug.log

--- a/packages/project-nitro/Dockerfile
+++ b/packages/project-nitro/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:10
+
+# Backstopjs - https://hub.docker.com/r/backstopjs/backstopjs/dockerfile
+ENV \
+PHANTOMJS_VERSION=2.1.16 \
+CASPERJS_VERSION=1.1.4 \
+SLIMERJS_VERSION=1.0.0 \
+BACKSTOPJS_VERSION=3.8.5 \
+# Workaround to fix phantomjs-prebuilt installation errors
+# See https://github.com/Medium/phantomjs/issues/707
+NPM_CONFIG_UNSAFE_PERM=true
+
+# Base packages
+RUN apt-get update && \
+apt-get install -y git sudo software-properties-common
+
+RUN sudo npm install -g --unsafe-perm=true --allow-root phantomjs-prebuilt@${PHANTOMJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root casperjs@${CASPERJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root slimerjs@${SLIMERJS_VERSION}
+RUN sudo npm install -g --unsafe-perm=true --allow-root backstopjs@${BACKSTOPJS_VERSION}
+
+RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub && sudo apt-key add linux_signing_key.pub
+RUN sudo add-apt-repository "deb http://dl.google.com/linux/chrome/deb/ stable main"
+
+RUN	apt-get -y update && \
+apt-get -y install google-chrome-stable
+
+RUN apt-get install -y firefox-esr
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+COPY .npmrc ./
+RUN npm install --ignore-optional
+
+# Bundle app source
+COPY . .
+
+# Expose and start server
+EXPOSE 8080 8081 3001
+CMD [ "npm", "start" ]

--- a/packages/project-nitro/docker-compose-dev.yml
+++ b/packages/project-nitro/docker-compose-dev.yml
@@ -1,0 +1,13 @@
+# docker-compose.yaml
+version: "3"
+services:
+  server:
+    build: .
+    container_name: project-nitro_server-dev
+    command: npm start
+    ports:
+    - 8081:8081
+    - 3001:3001
+    volumes:
+    - .:/app:rw
+    - /app/node_modules

--- a/packages/project-nitro/docker-compose.yml
+++ b/packages/project-nitro/docker-compose.yml
@@ -1,0 +1,9 @@
+# docker-compose.yaml for production (prototype)
+version: "3"
+services:
+  server:
+    build: .
+    container_name: project-nitro_server
+    command: npm run prod
+    ports:
+    - 8080:8080

--- a/packages/project-nitro/package.json
+++ b/packages/project-nitro/package.json
@@ -42,7 +42,13 @@
     "prod:build": "npm run build",
     "prod:serve": "cross-env NODE_ENV=production gulp serve",
     "start": "npm-run-all start:*",
-    "start:dev": "npm run dev"
+    "start:dev": "npm run dev",
+    "docker:update": "docker-compose build",
+    "docker:start": "npm run docker:dev:start",
+    "docker:dev:start": "docker-compose -f docker-compose-dev.yml up",
+    "docker:dev:console": "docker exec -it project-nitro_server-dev bash",
+    "docker:dev:watch": "docker-volume-watcher -e \"*.git*\" \"*build*\" \"*dist*\"",
+    "docker:prod": "docker-compose up"
   },
   "keywords": [
     "frontend",

--- a/packages/project-nitro/project/docs/nitro-docker.md
+++ b/packages/project-nitro/project/docs/nitro-docker.md
@@ -1,0 +1,44 @@
+# Nitro usage with docker
+
+This feature is currently in experimental status.
+
+Of course docker must be installed.
+
+## Production mode
+
+To start in production mode (prototype server):
+
+```
+npm run docker:prod
+```
+
+## Development mode
+
+To start in development mode:
+
+```
+npm run docker:start
+```
+
+⚠ Live reload for windows only works with an additional tool:
+
+Install [docker-windows-volume-watcher](https://github.com/merofeev/docker-windows-volume-watcher)
+and run:
+
+```
+npm run docker:dev:watch
+```
+
+If you need a console to the docker image, run:
+
+```
+npm run docker:dev:console
+```
+
+## Update Docker Image
+
+If you make changes to package.json or the Dockerfile you should recreate the docker image.
+
+```
+npm run docker:update
+```

--- a/packages/project-nitro/project/docs/nitro.md
+++ b/packages/project-nitro/project/docs/nitro.md
@@ -62,6 +62,10 @@ set PORT=8000 && set PROXY=8001 && npm start
 set PORT=3001 && npm run prod
 ```
 
+### Usage with docker (experimental)
+
+For information on how to use Nitro with docker, please refer to [nitro-docker.md](./nitro-docker.md) .
+
 ## Configuring
 
 ### Config Package

--- a/packages/project-nitro/readme.md
+++ b/packages/project-nitro/readme.md
@@ -19,6 +19,10 @@ and start in development mode
 npm start
 ```
 
+## Usage with docker (experimental)
+
+For information on how to use Nitro with docker, please refer to [nitro-docker.md](./project/docs/nitro-docker.md) .
+
 ## Nitro
 
 For information on how to use Nitro, please refer to [nitro.md](./project/docs/nitro.md) .


### PR DESCRIPTION
## Purpose of this pull request? 

* Enhancement

The pull request refers to the:

* generator (generator-nitro)
* example nitro project (project-nitro)

## What changes did you make?

Add docker configuration example for production and development. This should work for mac, windows and linux.
The main goal is to have a docker config for production. A second goal is to have a way to perform the visual tests platform independent.

This feature is tagged as experimental.