### PR TITLE
Feature: allow additional routes to be dumped and exported

### DIFF
--- a/packages/generator-nitro/generators/app/templates/project/docs/nitro-config.md
+++ b/packages/generator-nitro/generators/app/templates/project/docs/nitro-config.md
@@ -101,15 +101,15 @@ const config = {
 
 #### `nitro.mode.livereload`
 
-Type: Boolean  
-Default: true
+* Type: Boolean  
+* Default: true
 
 Browser livereload on changes (develop mode only)
 
 #### `nitro.mode.offline`
 
-Type: Boolean  
-Default: false
+* Type: Boolean  
+* Default: false
 
 If set to true, browsersync will be loaded in offline mode.  
 This property is passed as `_nitro.offline` to handlebars views.
@@ -118,8 +118,8 @@ This property is passed as `_nitro.offline` to handlebars views.
 
 #### `nitro.watch.partials`
 
-Type: Boolean  
-Default: true
+* Type: Boolean  
+* Default: true
 
 If set to false, handlebars partials won't be watched and recompiled on change.
 
@@ -136,38 +136,51 @@ Type: Object
 
 ### `server.port`
 
-Type: Integer
-Default: 8080
+* Type: Integer
+* Default: 8080
 
 The express server runs on this port.  
 An environment variable PORT will overwrite this property.
 
 ### `server.proxy`
 
-Type: Integer
-Default: 8081
+* Type: Integer
+* Default: 8081
 
 The proxy server with livereload functionality runs on this port.  
 An environment variable PROXY will overwrite this property.
 
 ### `server.compression`
 
-Type: Boolean
-Default: true
+* Type: Boolean
+* Default: true
 
 If set to `true`, all requests through express will be compressed.
 
 ## Gulp
 
-### `gulp.dumpViews.viewFilter`
+### `gulp.dumpViews`
 
-Type: function
+Type: object
 
 Used in gulp task `dump-views`
 
-Filters unwanted views (should return false for unwanted view urls)
+#### `gulp.dumpViews.viewFilter` 
+
+Type: Function
+
+Filters unwanted views (should return false for unwanted view urls). By default, all views will be dumped.
 
 e.g.: ```viewFilter: (url) => url !== 'incomplete'```
+
+#### `gulp.dumpViews.additionalRoutes` 
+
+Type: Array of Strings
+default: []
+
+The Task `dump-views` tries to save exactly these routes as well (file extension must be specified)
+
+e.g.: ```additionalRoutes:['api/service/countries.json']```
 
 ### `gulp.copyAssets`
 

--- a/packages/nitro-exporter/index.js
+++ b/packages/nitro-exporter/index.js
@@ -1,25 +1,44 @@
 'use strict';
 
+/* global process */
+
 const exportClean = require('./tasks/export-clean.js');
 const exportViews = require('./tasks/export-views.js');
 const exportProcessing = require('./tasks/export-processing.js');
 
-module.exports = function (gulp, config) {
-	const gulpSequence = require('gulp-sequence').use(gulp);
-	const shouldExportViews = !config.exporter.length ?
+function getMergedConfigProps(config) {
+	const collectedConfig = {};
+
+	collectedConfig.shouldExportViews = !config.exporter.length ?
 		config.exporter.views :
 		config.exporter.some((exporterConfig) => exporterConfig.views !== false);
+
+	collectedConfig.languages = !config.exporter.length ?
+		config.exporter.i18n :
+		config.exporter.reduce((acc, exporterConfig) => [...acc, ...exporterConfig.i18n], ['default']);
+
+	return collectedConfig;
+}
+
+module.exports = function (gulp, config) {
+	const gulpSequence = require('gulp-sequence').use(gulp);
+	const mergedConfig = getMergedConfigProps(config);
 
 	gulp.task('export-clean', exportClean(config));
 	gulp.task('export-views', () => exportViews(gulp, config));
 	gulp.task('export-processing', () => exportProcessing(gulp, config));
 
-	if (shouldExportViews) {
+	if (mergedConfig.shouldExportViews) {
+		if (mergedConfig.languages.length) {
+			// set global env to use in other gulp tasks
+			process.env.NITRO_VIEW_LOCALES = mergedConfig.languages.join(',');
+		}
+
 		gulp.task('export', gulpSequence(
 			'export-clean',
 			'dump-views',
 			'export-views',
-			'export-processing'
+			'export-processing',
 		));
 	} else {
 		gulp.task('export', gulpSequence(

--- a/packages/nitro-exporter/readme.md
+++ b/packages/nitro-exporter/readme.md
@@ -26,9 +26,7 @@ The distribution folder for your static export. This is where all your static fi
 
 ### exporter.i18n (Array)
 
-Contains a list of language keys. The views will be exported using the specified language keys.
-You have to specify all languages additionally for the `dump-views` task at [generator-nitro](https://github.com/namics/generator-nitro).
-The nitro-exporter will export all dumped views per default. You can filter out specific view exports by either setting `i18n` or `views` option.
+Contains a list of language keys. The views will be exported using the specified language keys. (use `default` for default language )
 
 - example: `['de']`
 

--- a/packages/nitro-exporter/tasks/export-views.js
+++ b/packages/nitro-exporter/tasks/export-views.js
@@ -11,19 +11,21 @@ module.exports = function (gulp, config) {
 	utils.each(config.exporter, (configEntry) => {
 		processes.push(
 			new Promise((resolve) => {
+				const ext = '(html|json)';
 				const i18nFilter = configEntry.i18n.length ?
-					configEntry.i18n.map((lng) => path.join(nitroTmpDirectory, `*-${lng}.html`)) :
-					path.join(nitroTmpDirectory, '*.html');
+					configEntry.i18n.map((lng) => path.join(nitroTmpDirectory, `*-${lng}.${ext}`)) :
+					path.join(nitroTmpDirectory, '**', `*.${ext}`);
+
 				if (configEntry.views === true) {
-					gulp.src(path.join(nitroTmpDirectory, '*.html'))
+					gulp.src(path.join(nitroTmpDirectory, '**', `*.${ext}`))
 						.pipe(filter(i18nFilter))
 						.pipe(gulp.dest(configEntry.dest))
 						.on('end', () => {
 							resolve();
 						});
 				} else if (Array.isArray(configEntry.views) && configEntry.views.length > 0) {
-					gulp.src(path.join(nitroTmpDirectory, '*.html'))
-						.pipe(filter(configEntry.views.map((v) => path.join(nitroTmpDirectory, `${v}.html`))))
+					gulp.src(path.join(nitroTmpDirectory, '**', `*.${ext}`))
+						.pipe(filter(configEntry.views.map((v) => path.join(nitroTmpDirectory, '**', `${v}.${ext}`))))
 						.pipe(filter(i18nFilter))
 						.pipe(gulp.dest(configEntry.dest))
 						.on('end', () => {

--- a/packages/nitro-exporter/tasks/export-views.js
+++ b/packages/nitro-exporter/tasks/export-views.js
@@ -11,29 +11,34 @@ module.exports = function (gulp, config) {
 	utils.each(config.exporter, (configEntry) => {
 		processes.push(
 			new Promise((resolve) => {
-				const ext = '(html|json)';
-				const i18nFilter = configEntry.i18n.length ?
-					configEntry.i18n.map((lng) => path.join(nitroTmpDirectory, `*-${lng}.${ext}`)) :
-					path.join(nitroTmpDirectory, '**', `*.${ext}`);
+				// allowed extensions for views and additional views
+				const extPattern = '{html,json}';
+				// check for language configuration
+				const langPattern = configEntry.i18n.length
+					? `-${configEntry.i18n.filter((lang) => lang !== 'default').join(',')}`
+					: '';
 
-				if (configEntry.views === true) {
-					gulp.src(path.join(nitroTmpDirectory, '**', `*.${ext}`))
-						.pipe(filter(i18nFilter))
-						.pipe(gulp.dest(configEntry.dest))
-						.on('end', () => {
-							resolve();
-						});
-				} else if (Array.isArray(configEntry.views) && configEntry.views.length > 0) {
-					gulp.src(path.join(nitroTmpDirectory, '**', `*.${ext}`))
-						.pipe(filter(configEntry.views.map((v) => path.join(nitroTmpDirectory, '**', `${v}.${ext}`))))
-						.pipe(filter(i18nFilter))
-						.pipe(gulp.dest(configEntry.dest))
-						.on('end', () => {
-							resolve();
-						});
-				} else {
-					resolve();
-				}
+				const hasViewArray = Array.isArray(configEntry.views) && configEntry.views.length > 0;
+				// views does not have file extensions
+				const viewPattern = hasViewArray
+					? `{${configEntry.views.filter((view) => !path.extname(view)).join(',')}}`
+					: '*';
+				// additional views must have a file extension
+				const additionalViews = hasViewArray
+					? configEntry.views.filter((view) => path.extname(view)).map((view) => path.join(nitroTmpDirectory, view))
+					: [];
+				// merge dumped views with additional views
+				const viewFilter = [
+					path.join(nitroTmpDirectory, `${viewPattern}${langPattern}.html`),
+					...additionalViews,
+				];
+
+				gulp.src(path.join(nitroTmpDirectory, '**', `*.${extPattern}`))
+					.pipe(filter(viewFilter))
+					.pipe(gulp.dest(configEntry.dest))
+					.on('end', () => {
+						resolve();
+					});
 			})
 		);
 	});

--- a/packages/project-nitro/config/default/exporter.js
+++ b/packages/project-nitro/config/default/exporter.js
@@ -63,7 +63,7 @@ const config = {
 					],
 				},
 			],
-			views: ['index', 'example-*'],
+			views: ['index', 'example-*', 'api/lottie/shipment.json', 'api/lottie/bouncing.json'],
 			zip: false,
 		},
 		{
@@ -120,7 +120,7 @@ const config = {
 					],
 				},
 			],
-			views: ['index', '404'],
+			views: true,
 			zip: true,
 		},
 	],

--- a/packages/project-nitro/config/default/gulp.js
+++ b/packages/project-nitro/config/default/gulp.js
@@ -10,6 +10,10 @@ const config = {
 			// filter corrupt, incomplete or irrelevant views
 			// example:
 			// viewFilter: (url) => url !== 'incomplete',
+			additionalRoutes: [
+				'api/lottie/shipment.json',
+				'api/lottie/bouncing.json',
+			],
 		},
 		copyAssets: [
 			// copies all source files to dest folder

--- a/packages/project-nitro/project/docs/nitro-config.md
+++ b/packages/project-nitro/project/docs/nitro-config.md
@@ -101,15 +101,15 @@ const config = {
 
 #### `nitro.mode.livereload`
 
-Type: Boolean  
-Default: true
+* Type: Boolean  
+* Default: true
 
 Browser livereload on changes (develop mode only)
 
 #### `nitro.mode.offline`
 
-Type: Boolean  
-Default: false
+* Type: Boolean  
+* Default: false
 
 If set to true, browsersync will be loaded in offline mode.  
 This property is passed as `_nitro.offline` to handlebars views.
@@ -118,8 +118,8 @@ This property is passed as `_nitro.offline` to handlebars views.
 
 #### `nitro.watch.partials`
 
-Type: Boolean  
-Default: true
+* Type: Boolean  
+* Default: true
 
 If set to false, handlebars partials won't be watched and recompiled on change.
 
@@ -136,38 +136,51 @@ Type: Object
 
 ### `server.port`
 
-Type: Integer
-Default: 8080
+* Type: Integer
+* Default: 8080
 
 The express server runs on this port.  
 An environment variable PORT will overwrite this property.
 
 ### `server.proxy`
 
-Type: Integer
-Default: 8081
+* Type: Integer
+* Default: 8081
 
 The proxy server with livereload functionality runs on this port.  
 An environment variable PROXY will overwrite this property.
 
 ### `server.compression`
 
-Type: Boolean
-Default: true
+* Type: Boolean
+* Default: true
 
 If set to `true`, all requests through express will be compressed.
 
 ## Gulp
 
-### `gulp.dumpViews.viewFilter`
+### `gulp.dumpViews`
 
-Type: function
+Type: object
 
 Used in gulp task `dump-views`
 
-Filters unwanted views (should return false for unwanted view urls)
+#### `gulp.dumpViews.viewFilter` 
+
+Type: Function
+
+Filters unwanted views (should return false for unwanted view urls). By default, all views will be dumped.
 
 e.g.: ```viewFilter: (url) => url !== 'incomplete'```
+
+#### `gulp.dumpViews.additionalRoutes` 
+
+Type: Array of Strings
+default: []
+
+The Task `dump-views` tries to save exactly these routes as well (file extension must be specified)
+
+e.g.: ```additionalRoutes:['api/service/countries.json']```
 
 ### `gulp.copyAssets`
 


### PR DESCRIPTION
## Purpose of this pull request?

* Enhancement

The pull request refers to the:

* nitro exporter (@nitro/exporter)
* nitro gulp tasks (@nitro/gulp)

## What changes did you make?

* @nitro/gulp: add possibility to add additinal routes for gulp task `dump-views` with property `gulp.dumpViews.additionalRoutes` in config
* @nitro/exporter: add possibility to add additional routes to the export.