### PR TITLE
chore: replace tslint with eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4269,9 +4269,9 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-			"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.4.0.tgz",
+			"integrity": "sha512-1mt8bw5JQWWTcwUM1FGjFJLFo5lB/jz6zbm+qwdEh2iqYobKS4aHWgz1d+mvho5cqCaShFDF+hnpgraIi/5tqA==",
 			"dev": true
 		},
 		"node-fetch-npm": {

--- a/packages/generator-nitro/generators/app/templates/.eslintrc-typescript.js
+++ b/packages/generator-nitro/generators/app/templates/.eslintrc-typescript.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: [
+		'@namics/eslint-config/configurations/typescript-browser.js',
+		'@namics/eslint-config/configurations/typescript-browser-disable-styles.js',
+	].map(require.resolve),
+	rules: {},
+};

--- a/packages/generator-nitro/generators/app/templates/package.json
+++ b/packages/generator-nitro/generators/app/templates/package.json
@@ -25,9 +25,9 @@
     "lint:css": "stylelint src/**/*.*ss",
     "lint:data": "nitro-app-validate-pattern-data",
     "lint:html": "gulp lint-html",
-    "lint:js": "eslint ./src",
+    "lint:js": "eslint ./src --ext .js",
     "lint:license": "license-checker --production --summary --exclude \"Apache-2.0, BSD, ISC, LGPL, MIT, MPL\" --failOn \"AGPL; EPL; GPL\"",
-    "lint:ts": "tslint 'src/**/*.{ts,tsx}'",
+    "XXXlint:ts": "eslint ./src --ext .ts,.tsx --config .eslintrc-typescript.js",
     "prettier": "prettier --write \"**/*.*(js|jsx|ts|tsx|json)\"",
     "test": "npm-run-all test:*",
     "test:lint": "npm run lint",
@@ -86,10 +86,10 @@
     "tota11y": "0.1.6"<% } %>
   },
   "devDependencies": {
-    "@namics/eslint-config": "6.1.0",
+    "@namics/eslint-config": "7.0.1",
     "@namics/prettier-config": "0.2.0",
     "@namics/stylelint-config": "0.2.2",
-    "@namics/tslint-config": "0.2.1",
+    "@namics/ts-config": "0.2.0",
     "@nitro/app": "<%= version %>",
     "@nitro/exporter": "<%= version %>",
     "@nitro/gulp": "<%= version %>",
@@ -118,8 +118,6 @@
     "prettier": "1.15.2",
     "rimraf": "2.6.3",
     "stylelint": "10.0.1",
-    "tslint": "5.16.0",
-    "tslint-config-prettier": "1.18.0",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1",
     "yo": "2.0.6"
@@ -156,7 +154,7 @@
     ],
     "src/**/*.{ts,tsx}": [
       "prettier --list-different --write",
-      "tslint"
+      "eslint --config .eslintrc-typescript.js"
     ]
   }
 }

--- a/packages/generator-nitro/generators/app/templates/tsconfig.json
+++ b/packages/generator-nitro/generators/app/templates/tsconfig.json
@@ -1,22 +1,5 @@
 {
-	"compilerOptions": {
-		"sourceMap": true,
-		"skipLibCheck": true,
-		"target": "es5",
-		"module": "esnext",
-		"jsx": "react",
-		"allowSyntheticDefaultImports": true,
-		"moduleResolution": "node",
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"declaration": true,
-		"noImplicitAny": false,
-		"noImplicitReturns": true,
-		"strictNullChecks": true,
-		"removeComments": false,
-		"outDir": "dist",
-		"lib": ["es6", "es7", "dom"]
-	},
+	"extends": "@namics/ts-config/tsconfig.json",
 	"include": ["src/**/*"],
 	"exclude": ["dist", "build", "public", "node_modules"]
 }

--- a/packages/generator-nitro/generators/app/templates/tslint.json
+++ b/packages/generator-nitro/generators/app/templates/tslint.json
@@ -1,7 +1,0 @@
-{
-	"defaultSeverity": "error",
-	"extends": ["@namics/tslint-config", "tslint-config-prettier"],
-	"jsRules": {},
-	"rules": {},
-	"rulesDirectory": []
-}

--- a/packages/generator-nitro/package.json
+++ b/packages/generator-nitro/package.json
@@ -42,7 +42,7 @@
     "yosay": "2.0.2"
   },
   "devDependencies": {
-    "@namics/eslint-config": "6.1.0",
+    "@namics/eslint-config": "7.0.1",
     "ejs": "2.6.1",
     "eslint": "5.16.0",
     "eslint-plugin-import": "2.17.2",

--- a/packages/nitro-app/package.json
+++ b/packages/nitro-app/package.json
@@ -54,7 +54,7 @@
     "webpack-hot-middleware": "2.24.4"
   },
   "devDependencies": {
-    "@namics/eslint-config": "6.1.0",
+    "@namics/eslint-config": "7.0.1",
     "eslint": "5.16.0",
     "eslint-plugin-import": "2.17.2",
     "pkg-ok": "2.3.1"

--- a/packages/nitro-exporter/package.json
+++ b/packages/nitro-exporter/package.json
@@ -33,7 +33,7 @@
     "gulp-vinyl-zip": "2.1.2"
   },
   "devDependencies": {
-    "@namics/eslint-config": "6.1.0",
+    "@namics/eslint-config": "7.0.1",
     "eslint": "5.16.0",
     "eslint-plugin-import": "2.17.2",
     "pkg-ok": "2.3.1"

--- a/packages/nitro-gulp/package.json
+++ b/packages/nitro-gulp/package.json
@@ -52,7 +52,7 @@
     "yargs": "13.2.2"
   },
   "devDependencies": {
-    "@namics/eslint-config": "6.1.0",
+    "@namics/eslint-config": "7.0.1",
     "@nitro/app": "*",
     "eslint": "5.16.0",
     "eslint-plugin-import": "2.17.2",

--- a/packages/nitro-webpack/package.json
+++ b/packages/nitro-webpack/package.json
@@ -62,7 +62,7 @@
     "webpack-bundle-analyzer": "3.3.2"
   },
   "devDependencies": {
-    "@namics/eslint-config": "6.1.0",
+    "@namics/eslint-config": "7.0.1",
     "pkg-ok": "2.3.1"
   },
   "publishConfig": {

--- a/packages/project-nitro-twig/.eslintrc-typescript.js
+++ b/packages/project-nitro-twig/.eslintrc-typescript.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: [
+		'@namics/eslint-config/configurations/typescript-browser.js',
+		'@namics/eslint-config/configurations/typescript-browser-disable-styles.js',
+	].map(require.resolve),
+	rules: {},
+};

--- a/packages/project-nitro-twig/package.json
+++ b/packages/project-nitro-twig/package.json
@@ -25,9 +25,9 @@
     "lint:css": "stylelint src/**/*.*ss",
     "lint:data": "nitro-app-validate-pattern-data",
     "lint:html": "gulp lint-html",
-    "lint:js": "eslint ./src",
+    "lint:js": "eslint ./src --ext .js",
     "lint:license": "license-checker --production --summary --exclude \"Apache-2.0, BSD, ISC, LGPL, MIT, MPL\" --failOn \"AGPL; EPL; GPL\"",
-    "lint:ts": "tslint 'src/**/*.{ts,tsx}'",
+    "XXXlint:ts": "eslint ./src --ext .ts,.tsx --config .eslintrc-typescript.js",
     "prettier": "prettier --write \"**/*.*(js|jsx|ts|tsx|json)\"",
     "test": "npm-run-all test:*",
     "test:lint": "npm run lint",
@@ -86,10 +86,10 @@
     "tota11y": "0.1.6"
   },
   "devDependencies": {
-    "@namics/eslint-config": "6.1.0",
+    "@namics/eslint-config": "7.0.1",
     "@namics/prettier-config": "0.2.0",
     "@namics/stylelint-config": "0.2.2",
-    "@namics/tslint-config": "0.2.1",
+    "@namics/ts-config": "0.2.0",
     "@nitro/app": "*",
     "@nitro/exporter": "*",
     "@nitro/gulp": "*",
@@ -118,8 +118,6 @@
     "prettier": "1.15.2",
     "rimraf": "2.6.3",
     "stylelint": "10.0.1",
-    "tslint": "5.16.0",
-    "tslint-config-prettier": "1.18.0",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1",
     "yo": "2.0.6"
@@ -156,7 +154,7 @@
     ],
     "src/**/*.{ts,tsx}": [
       "prettier --list-different --write",
-      "tslint"
+      "eslint --config .eslintrc-typescript.js"
     ]
   }
 }

--- a/packages/project-nitro-twig/tsconfig.json
+++ b/packages/project-nitro-twig/tsconfig.json
@@ -1,22 +1,5 @@
 {
-	"compilerOptions": {
-		"sourceMap": true,
-		"skipLibCheck": true,
-		"target": "es5",
-		"module": "esnext",
-		"jsx": "react",
-		"allowSyntheticDefaultImports": true,
-		"moduleResolution": "node",
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"declaration": true,
-		"noImplicitAny": false,
-		"noImplicitReturns": true,
-		"strictNullChecks": true,
-		"removeComments": false,
-		"outDir": "dist",
-		"lib": ["es6", "es7", "dom"]
-	},
+	"extends": "@namics/ts-config/tsconfig.json",
 	"include": ["src/**/*"],
 	"exclude": ["dist", "build", "public", "node_modules"]
 }

--- a/packages/project-nitro-twig/tslint.json
+++ b/packages/project-nitro-twig/tslint.json
@@ -1,7 +1,0 @@
-{
-	"defaultSeverity": "error",
-	"extends": ["@namics/tslint-config", "tslint-config-prettier"],
-	"jsRules": {},
-	"rules": {},
-	"rulesDirectory": []
-}

--- a/packages/project-nitro/.eslintrc-typescript.js
+++ b/packages/project-nitro/.eslintrc-typescript.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: [
+		'@namics/eslint-config/configurations/typescript-browser.js',
+		'@namics/eslint-config/configurations/typescript-browser-disable-styles.js',
+	].map(require.resolve),
+	rules: {},
+};

--- a/packages/project-nitro/config/webpack/options.js
+++ b/packages/project-nitro/config/webpack/options.js
@@ -10,15 +10,15 @@ const options = {
 		},
 		hbs: true,
 		woff: {
-			exclude: [ /slick-carousel/ ],
+			exclude: [/slick-carousel/],
 		},
 		// ⚠ use font rule with care - processes also svg and woff files
 		// ⚠ use includes and excludes also in 'image' and 'woff' loader config
 		font: {
-			include: [ /slick-carousel/ ],
+			include: [/slick-carousel/],
 		},
 		image: {
-			exclude: [ /slick-carousel.*\.svg/ ],
+			exclude: [/slick-carousel.*\.svg/],
 		},
 	},
 	features: {

--- a/packages/project-nitro/package.json
+++ b/packages/project-nitro/package.json
@@ -25,9 +25,9 @@
     "lint:css": "stylelint src/**/*.*ss",
     "lint:data": "nitro-app-validate-pattern-data",
     "lint:html": "gulp lint-html",
-    "lint:js": "eslint ./src",
+    "lint:js": "eslint ./src --ext .js",
     "lint:license": "license-checker --production --summary --exclude \"Apache-2.0, BSD, ISC, LGPL, MIT, MPL\" --failOn \"AGPL; EPL; GPL\"",
-    "lint:ts": "tslint 'src/**/*.{ts,tsx}'",
+    "XXXlint:ts": "eslint ./src --ext .ts,.tsx --config .eslintrc-typescript.js",
     "prettier": "prettier --write \"**/*.*(js|jsx|ts|tsx|json)\"",
     "test": "npm-run-all test:*",
     "test:lint": "npm run lint",
@@ -87,10 +87,10 @@
     "tota11y": "0.1.6"
   },
   "devDependencies": {
-    "@namics/eslint-config": "6.1.0",
+    "@namics/eslint-config": "7.0.1",
     "@namics/prettier-config": "0.2.0",
     "@namics/stylelint-config": "0.2.2",
-    "@namics/tslint-config": "0.2.1",
+    "@namics/ts-config": "0.2.0",
     "@nitro/app": "*",
     "@nitro/exporter": "*",
     "@nitro/gulp": "*",
@@ -119,8 +119,6 @@
     "prettier": "1.15.2",
     "rimraf": "2.6.3",
     "stylelint": "10.0.1",
-    "tslint": "5.16.0",
-    "tslint-config-prettier": "1.18.0",
     "webpack": "4.30.0",
     "webpack-cli": "3.3.1",
     "yo": "2.0.6"
@@ -157,7 +155,7 @@
     ],
     "src/**/*.{ts,tsx}": [
       "prettier --list-different --write",
-      "tslint"
+      "eslint --config .eslintrc-typescript.js"
     ]
   }
 }

--- a/packages/project-nitro/tsconfig.json
+++ b/packages/project-nitro/tsconfig.json
@@ -1,22 +1,5 @@
 {
-	"compilerOptions": {
-		"sourceMap": true,
-		"skipLibCheck": true,
-		"target": "es5",
-		"module": "esnext",
-		"jsx": "react",
-		"allowSyntheticDefaultImports": true,
-		"moduleResolution": "node",
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"declaration": true,
-		"noImplicitAny": false,
-		"noImplicitReturns": true,
-		"strictNullChecks": true,
-		"removeComments": false,
-		"outDir": "dist",
-		"lib": ["es6", "es7", "dom"]
-	},
+	"extends": "@namics/ts-config/tsconfig.json",
 	"include": ["src/**/*"],
 	"exclude": ["dist", "build", "public", "node_modules"]
 }

--- a/packages/project-nitro/tslint.json
+++ b/packages/project-nitro/tslint.json
@@ -1,7 +1,0 @@
-{
-	"defaultSeverity": "error",
-	"extends": ["@namics/tslint-config", "tslint-config-prettier"],
-	"jsRules": {},
-	"rules": {},
-	"rulesDirectory": []
-}


### PR DESCRIPTION
## Purpose of this pull request? 

Eslint can also lint TypeScript.
The pull request refers to all packages

## What changes did you make?

Remove tslint in favor of eslint and adapt default configuration.
Currently JavaScript is the default language, so we need a separate eslint config for TypeScript.