### PR TITLE
If example code not selected then generated package.json was not valid.

### DIFF
--- a/packages/generator-nitro/generators/app/templates/package.json
+++ b/packages/generator-nitro/generators/app/templates/package.json
@@ -84,7 +84,7 @@
     "lodash": "4.17.15",
     "lottie-web": "5.5.9",
     "prevent-window-opener-attacks": "0.2.4",<% } %>
-    "regenerator-runtime": "0.13.3",<% if (options.exampleCode) { %>
+    "regenerator-runtime": "0.13.3"<% if (options.exampleCode) { %>,
     "svg4everybody": "2.1.9",
     "tota11y": "0.1.6"<% } %>
   },


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a pull request
-->

## Purpose of this pull request? 
If example code not selected then generated package.json was not valid.
`  "dependencies": {
    "core-js": "3.2.1",
    "regenerator-runtime": "0.13.3",
  },`
* Bug fix

The pull request refers to the:

* generator (generator-nitro)

## What changes did you make?
placing a comma inside example code option block prevent the generation of invalid package.json that will skip comma generation if there is no example code selected. 

## Is there anything you'd like reviewers to focus on?
Loved your work. Keep it up. 
