### PR TITLE
feat(generator): load scripts in head with defer-attribute

### DIFF
--- a/packages/generator-nitro/generators/app/templates/project/docs/nitro.md
+++ b/packages/generator-nitro/generators/app/templates/project/docs/nitro.md
@@ -483,7 +483,7 @@ Link to resources relatively to the `project`-folder **with** a leading slash.
 ```html
 <link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.js"></script>
 <a href="/content">Contentpage</a>
 ```
 

--- a/packages/generator-nitro/generators/app/templates/src/views/_partials/foot.hbs
+++ b/packages/generator-nitro/generators/app/templates/src/views/_partials/foot.hbs
@@ -1,3 +1,1 @@
-<script src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+

--- a/packages/generator-nitro/generators/app/templates/src/views/_partials/foot.twig
+++ b/packages/generator-nitro/generators/app/templates/src/views/_partials/foot.twig
@@ -1,3 +1,1 @@
-<script src="/assets/js/vendors{% if _nitro.production %}.min{% endif %}.js"></script>
-<script src="/assets/js/ui{% if _nitro.production %}.min{% endif %}.js"></script>
-<script src="/assets/js/proto{% if _nitro.production %}.min{% endif %}.js"></script>
+

--- a/packages/generator-nitro/generators/app/templates/src/views/_partials/head.hbs
+++ b/packages/generator-nitro/generators/app/templates/src/views/_partials/head.hbs
@@ -11,3 +11,6 @@
 <title>{{_nitro.pageTitle}}</title>
 <link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
 <link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
+<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>

--- a/packages/generator-nitro/generators/app/templates/src/views/_partials/head.twig
+++ b/packages/generator-nitro/generators/app/templates/src/views/_partials/head.twig
@@ -11,3 +11,6 @@
 <title>{{ _nitro.pageTitle }}</title>
 <link href="/assets/css/ui{% if _nitro.production %}.min{% endif %}.css" rel="stylesheet">
 <link href="/assets/css/proto{% if _nitro.production %}.min{% endif %}.css" rel="stylesheet">
+<script defer src="/assets/js/vendors{% if _nitro.production %}.min{% endif %}.js"></script>
+<script defer src="/assets/js/ui{% if _nitro.production %}.min{% endif %}.js"></script>
+<script defer src="/assets/js/proto{% if _nitro.production %}.min{% endif %}.js"></script>

--- a/packages/project-nitro-twig/project/docs/nitro.md
+++ b/packages/project-nitro-twig/project/docs/nitro.md
@@ -448,7 +448,7 @@ Link to resources relatively to the `project`-folder **with** a leading slash.
 ```html
 <link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.js"></script>
 <a href="/content">Contentpage</a>
 ```
 

--- a/packages/project-nitro-twig/src/views/_partials/foot.twig
+++ b/packages/project-nitro-twig/src/views/_partials/foot.twig
@@ -1,3 +1,1 @@
-<script src="/assets/js/vendors{% if _nitro.production %}.min{% endif %}.js"></script>
-<script src="/assets/js/ui{% if _nitro.production %}.min{% endif %}.js"></script>
-<script src="/assets/js/proto{% if _nitro.production %}.min{% endif %}.js"></script>
+

--- a/packages/project-nitro-twig/src/views/_partials/head.twig
+++ b/packages/project-nitro-twig/src/views/_partials/head.twig
@@ -11,3 +11,6 @@
 <title>{{ _nitro.pageTitle }}</title>
 <link href="/assets/css/ui{% if _nitro.production %}.min{% endif %}.css" rel="stylesheet">
 <link href="/assets/css/proto{% if _nitro.production %}.min{% endif %}.css" rel="stylesheet">
+<script defer src="/assets/js/vendors{% if _nitro.production %}.min{% endif %}.js"></script>
+<script defer src="/assets/js/ui{% if _nitro.production %}.min{% endif %}.js"></script>
+<script defer src="/assets/js/proto{% if _nitro.production %}.min{% endif %}.js"></script>

--- a/packages/project-nitro-typescript/project/docs/nitro.md
+++ b/packages/project-nitro-typescript/project/docs/nitro.md
@@ -462,7 +462,7 @@ Link to resources relatively to the `project`-folder **with** a leading slash.
 ```html
 <link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.js"></script>
 <a href="/content">Contentpage</a>
 ```
 

--- a/packages/project-nitro-typescript/src/views/_partials/foot.hbs
+++ b/packages/project-nitro-typescript/src/views/_partials/foot.hbs
@@ -1,3 +1,1 @@
-<script src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+

--- a/packages/project-nitro-typescript/src/views/_partials/head.hbs
+++ b/packages/project-nitro-typescript/src/views/_partials/head.hbs
@@ -11,3 +11,6 @@
 <title>{{_nitro.pageTitle}}</title>
 <link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
 <link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
+<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>

--- a/packages/project-nitro/project/docs/nitro.md
+++ b/packages/project-nitro/project/docs/nitro.md
@@ -462,7 +462,7 @@ Link to resources relatively to the `project`-folder **with** a leading slash.
 ```html
 <link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.js"></script>
 <a href="/content">Contentpage</a>
 ```
 

--- a/packages/project-nitro/src/views/_partials/foot.hbs
+++ b/packages/project-nitro/src/views/_partials/foot.hbs
@@ -1,3 +1,0 @@
-<script src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>

--- a/packages/project-nitro/src/views/_partials/head.hbs
+++ b/packages/project-nitro/src/views/_partials/head.hbs
@@ -11,3 +11,6 @@
 <title>{{_nitro.pageTitle}}</title>
 <link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
 <link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
+<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>

--- a/packages/project-prod/src/views/_partials/foot.hbs
+++ b/packages/project-prod/src/views/_partials/foot.hbs
@@ -1,3 +1,0 @@
-<script src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>

--- a/packages/project-prod/src/views/_partials/head.hbs
+++ b/packages/project-prod/src/views/_partials/head.hbs
@@ -11,3 +11,6 @@
 <title>{{_nitro.pageTitle}}</title>
 <link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
 <link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
+<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>


### PR DESCRIPTION
#169

I followed [these steps](https://github.com/namics/generator-nitro/blob/develop/docs/working-with-this-repo.md#develop-a-feature) which were very helpful 😄and when I tested it, the generated project in project-new has the script tag in the head with the defer attribute, just like I assumed it would.  🎉 I was wondering whether or not to remove the foot partial since there would be nothing in there anymore. What do you think @ernscht?

* Enhancement

The pull request refers to the:

* generator (generator-nitro)
* example nitro project (project-nitro)
* example nitro project with twig engine (project-nitro-twig)
