### PR TITLE
feat(project): add hbs asset helper

### DIFF
--- a/packages/generator-nitro/generators/app/templates/project/docs/nitro.md
+++ b/packages/generator-nitro/generators/app/templates/project/docs/nitro.md
@@ -404,6 +404,8 @@ You may overwrite data from views & patterns in request parameters.
 
 ## Assets
 
+For final use, all assets are copied from the 'src' to the 'public' folder.
+
 ### Webpack
 
 The main assets will be bundled with an easy to use webpack config.
@@ -413,19 +415,29 @@ clientside handlebars, webfonts and images (with minification). It also includes
 
 You only have to enable the desired loaders and features. And of course, it is possible to extend the configuration to your needs.
 
-The configuration is placed in `/config/webpack`  
+The configuration is placed in '/config/webpack'  
 See [readme](./nitro-webpack.md) for configuration options.
 
 ### Other Assets
 
 Nitro also gives you some gulp tasks to use for additional assets you need in your build.
-You may copy assets, minify images or generate an svg sprites.
+You may copy assets, minify images or generate svg sprites.
 
-Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and [`gulpfile.js`](../../gulpfile.js)
+Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and ['gulpfile.js'](../../gulpfile.js)
 
 ### Prototype Assets
 
-Place [code for development](../../src/proto/readme.md) in the corresponding directories.
+Place [code for development](../../src/proto/readme.md) in the corresponding directories.<% if (options.templateEngine !== 'twig') { %>
+
+### Asset helper
+
+The asset helper makes it possible to easily link your public assets in your markup.
+It can be used to change asset pathes depending on the environment.
+
+```
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+```<% } %>
 
 ## Translations
 
@@ -481,11 +493,16 @@ To stay consistent you should favour the use of relative paths with a leading sl
 Link to resources relatively to the `project`-folder **with** a leading slash.
 
 ```html
-<link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
+<link rel="stylesheet" href="/assets/css/ui.min.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script defer src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.min.js"></script>
 <a href="/content">Contentpage</a>
+```<% if (options.templateEngine !== 'twig') { %>
+
+...or use the 'asset' .hbs helper for public assets 
 ```
+<link rel="stylesheet" href="{{asset name='/css/ui.min.css'}}" type="text/css" />
+```<% } %>
 
 ### Upper & lower case letters
 

--- a/packages/nitro-app/app/templating/hbs/helpers/asset.js
+++ b/packages/nitro-app/app/templating/hbs/helpers/asset.js
@@ -1,0 +1,28 @@
+/**
+ * asset helper, can be used to change asset pathes depending on the environment
+ * - prefix assets with the correct path of their environment
+ * - use minified version only on production environment
+ *
+ * Usage:
+ *
+ * {{asset name='/css/ui.min.css'}}
+ * (will load public/assets/css/ui.css on development environment)
+ *
+ * {{asset name='/img/icon/favicon-32x32.png'}}
+ */
+
+const hbs = require('hbs');
+const path = require('path');
+
+module.exports = function(context) {
+	const contextDataRoot = context.data && context.data.root ? context.data.root : {};
+	let name = context.hash.name;
+
+	// remove .min from asset on development environment
+	if (!contextDataRoot._nitro.production) {
+		name = name.replace(/\.min\./, '.');
+	}
+
+	const assetPath = path.join('/assets/', name).replace(/\\/g, '/');
+	return new hbs.SafeString(assetPath);
+};

--- a/packages/project-nitro-twig/project/docs/nitro.md
+++ b/packages/project-nitro-twig/project/docs/nitro.md
@@ -12,7 +12,7 @@ Nitro is simple, fast and flexible. Use this app for all your frontend work.
 -   Webpack Builder with HMR
 -   Gulp Tasks for additional functionality
 -   Linting, Source Maps, PostCSS & Browsersync
--   Setup for unit, e2e and visual regression testing (cypress, backstopjs) & lighthouse
+-   Setup for e2e and visual regression testing (cypress, backstopjs) & lighthouse
 -   Pattern generator
 -   [Client side templates](./client-templates.md)
 -   [Static Exports](./nitro-exporter.md)
@@ -264,7 +264,7 @@ Render a partial (twig snippet). Partials are placed in `src/views/_partials/` a
 
 ### Render placeholders
 
-Using a placeholder is another way to output some markup. Placeholders are placed in a folder inside `/src/views/_placeholders/` as `*.twig` files.
+Using a placeholder is another way to output some markup. Placeholders are placed in a folder inside `/src/views/_placeholders/` as `*.twig` files.  
 The following example renders the file `content/example.twig` from `/src/views/_placeholders/`.
 
 ```
@@ -327,20 +327,20 @@ If you need a different layout for a page, do so in the corresponding view data 
 (View data files needs to be placed in same directory structure than views)
 
 ```
-    /src/views/_data/index.json
-    {
-        "_layout": "home"
-    }
+# /src/views/_data/index.json
+{
+    "_layout": "home"
+}
 
-    /src/views/_layouts/home.twig
-    http://localhost:8080/index
+# /src/views/_layouts/home.twig
+http://localhost:8080/index
 ```
 
 ...or you may change the layout temporarily by requesting a page with the query param `?_layout=...`
 
 ```
-/src/views/index.twig
-/src/views/_layouts/home.twig
+# /src/views/index.twig
+# /src/views/_layouts/home.twig
 http://localhost:8080/index?_layout=home
 ```
 

--- a/packages/project-nitro-twig/project/docs/nitro.md
+++ b/packages/project-nitro-twig/project/docs/nitro.md
@@ -76,7 +76,7 @@ For information on how to use Nitro with docker, please refer to [nitro-docker.m
 
 Nitro uses the flexible [config package](https://www.npmjs.com/package/config) for project configuration.
 This lets you to extend the default configuration for different deployment environments or local usage.  
-See details in [config readme](nitro-config.md)
+See details in [config readme](./nitro-config.md)
 
 ### Global Configuration
 
@@ -273,7 +273,7 @@ The following example renders the file `content/example.twig` from `/src/views/_
 
 ### Render page lists
 
-To render all pages in the `src/views` folder, just call the hbs helper <% if (options.templateEngine === 'twig') { %>`{% viewlist %}`<% } else { %>`{{viewlist}}`<% } %>. The helper renders an `<ul>` list 
+To render all pages in the `src/views` folder, just call the hbs helper `{% viewlist %}`. The helper renders an `<ul>` list 
 containing links to the respective pages.
 
 #### Filter generated list
@@ -300,29 +300,25 @@ With parameter include and exclude combined, all views containing at least one o
 
 #### Data per page
 
-You may pass data to your templates (view, layout, partial, pattern) per view.
+You may pass data to your templates (view, layout, partial, pattern) per view.  
 Put a file with the same name as the view in the folder `/src/views/_data/` with the file extension `.json`. (Use the same folder structure as in `/src/views`)
 
 ```
-
 /src/views/index.twig
-/src/views/\_data/index.json
+/src/views/_data/index.json
 http://localhost:8080/index
 
 /src/views/content/variant.twig
-/src/views/\_data/content/variant.json
+/src/views/_data/content/variant.json
 http://localhost:8080/content-variant
-
 ```
 
 It's also possible to use a custom data file by requesting with a query param `?_data=...`:
 
 ```
-
 /src/views/index.twig
-/src/views/\_data/index-test.json
+/src/views/_data/index-test.json
 http://localhost:8080/index?_data=index-test
-
 ```
 
 ##### Use different layout
@@ -331,30 +327,26 @@ If you need a different layout for a page, do so in the corresponding view data 
 (View data files needs to be placed in same directory structure than views)
 
 ```
+    /src/views/_data/index.json
+    {
+        "_layout": "home"
+    }
 
-/src/views/_data/index.json
-{
-    "_layout": "home"
-}
-
-/src/views/_layouts/home.twig
-http://localhost:8080/index
-
+    /src/views/_layouts/home.twig
+    http://localhost:8080/index
 ```
 
 ...or you may change the layout temporarily by requesting a page with the query param `?_layout=...`
 
 ```
-
 /src/views/index.twig
-/src/views/\_layouts/home.twig
+/src/views/_layouts/home.twig
 http://localhost:8080/index?_layout=home
-
-````
+```
 
 ##### Side Note About Extending Data
 
-Don't overload the view data. It will be deep extended with other data from patterns, request parameters, ....
+Don't overload the view data. It will be deep extended with other data from patterns, request parameters, ....  
 It's not recommended to use view data for data variations of patterns.
 
 #### Dynamic view data
@@ -374,6 +366,8 @@ You may overwrite data from views & patterns in request parameters.
 
 ## Assets
 
+For final use, all assets are copied from the 'src' to the 'public' folder.
+
 ### Webpack
 
 The main assets will be bundled with an easy to use webpack config.
@@ -383,15 +377,15 @@ clientside handlebars, webfonts and images (with minification). It also includes
 
 You only have to enable the desired loaders and features. And of course, it is possible to extend the configuration to your needs.
 
-The configuration is placed in `/config/webpack`
+The configuration is placed in '/config/webpack'  
 See [readme](./nitro-webpack.md) for configuration options.
 
 ### Other Assets
 
 Nitro also gives you some gulp tasks to use for additional assets you need in your build.
-You may copy assets, minify images or generate an svg sprites.
+You may copy assets, minify images or generate svg sprites.
 
-Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and [`gulpfile.js`](../../gulpfile.js)
+Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and ['gulpfile.js'](../../gulpfile.js)
 
 ### Prototype Assets
 
@@ -399,13 +393,13 @@ Place [code for development](../../src/proto/readme.md) in the corresponding dir
 
 ## Translations
 
-Nitro uses [i18next](https://www.npmjs.com/package/i18next) as Translation Library and gives you the helper described in the following section.
+Nitro uses [i18next](https://www.npmjs.com/package/i18next) as Translation Library and gives you the helper described in the following section.  
 Translations are stored in `/project/locales/[lang]/translation.json`.
 
 Express Middleware configuration:
 
-* Fallback language: `default`
-* Language switch with query parameter: `?lang=de`
+-   Fallback language: `default`
+-   Language switch with query parameter: `?lang=de`
 
 ### Translation twig helper
 
@@ -416,16 +410,15 @@ or use `%s` placeholders for sprintf functionality.
 
 Some examples:
 
-```js
-
+```
 data = {
-    name: 'developer'
+   name: 'developer'
 }
 
 "test": {
     "example": {
         "string" : "gold",
-        "nested": "All that glitters is not \$t(test.example.string).",
+        "nested": "All that glitters is not $t(test.example.string).",
         "sprintf" : "The first three letters of %s are: %s, %s and %s",
         "interpolation" : "Hello {{name}}"
     }
@@ -435,8 +428,7 @@ data = {
 {% t 'test.example.nested' %}
 {% t 'test.example.sprintf' data=['alphabet', 'a', 'l', 'p'] %}
 {% t 'test.example.interpolation' data={ name:'developer' } %}
-
-````
+```
 
 ## Conventions
 
@@ -446,9 +438,9 @@ To stay consistent you should favour the use of relative paths with a leading sl
 Link to resources relatively to the `project`-folder **with** a leading slash.
 
 ```html
-<link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
+<link rel="stylesheet" href="/assets/css/ui.min.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script defer src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.min.js"></script>
 <a href="/content">Contentpage</a>
 ```
 

--- a/packages/project-nitro-typescript/project/docs/nitro.md
+++ b/packages/project-nitro-typescript/project/docs/nitro.md
@@ -389,6 +389,8 @@ You may overwrite data from views & patterns in request parameters.
 
 ## Assets
 
+For final use, all assets are copied from the 'src' to the 'public' folder.
+
 ### Webpack
 
 The main assets will be bundled with an easy to use webpack config.
@@ -398,19 +400,29 @@ clientside handlebars, webfonts and images (with minification). It also includes
 
 You only have to enable the desired loaders and features. And of course, it is possible to extend the configuration to your needs.
 
-The configuration is placed in `/config/webpack`  
+The configuration is placed in '/config/webpack'  
 See [readme](./nitro-webpack.md) for configuration options.
 
 ### Other Assets
 
 Nitro also gives you some gulp tasks to use for additional assets you need in your build.
-You may copy assets, minify images or generate an svg sprites.
+You may copy assets, minify images or generate svg sprites.
 
-Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and [`gulpfile.js`](../../gulpfile.js)
+Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and ['gulpfile.js'](../../gulpfile.js)
 
 ### Prototype Assets
 
 Place [code for development](../../src/proto/readme.md) in the corresponding directories.
+
+### Asset helper
+
+The asset helper makes it possible to easily link your public assets in your markup.
+It can be used to change asset pathes depending on the environment.
+
+```
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+```
 
 ## Translations
 
@@ -460,10 +472,15 @@ To stay consistent you should favour the use of relative paths with a leading sl
 Link to resources relatively to the `project`-folder **with** a leading slash.
 
 ```html
-<link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
+<link rel="stylesheet" href="/assets/css/ui.min.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script defer src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.min.js"></script>
 <a href="/content">Contentpage</a>
+```
+
+...or use the 'asset' .hbs helper for public assets 
+```
+<link rel="stylesheet" href="{{asset name='/css/ui.min.css'}}" type="text/css" />
 ```
 
 ### Upper & lower case letters

--- a/packages/project-nitro-typescript/src/patterns/atoms/icon/icon.hbs
+++ b/packages/project-nitro-typescript/src/patterns/atoms/icon/icon.hbs
@@ -1,3 +1,3 @@
 <svg class="a-icon" xmlns="http://www.w3.org/2000/svg">
-	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svg/icons.svg#{{icon}}"></use>
+	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{asset name='/svg/icons.svg'}}#{{icon}}"></use>
 </svg>

--- a/packages/project-nitro-typescript/src/views/_partials/head.hbs
+++ b/packages/project-nitro-typescript/src/views/_partials/head.hbs
@@ -3,14 +3,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Nitro - {{_nitro.pageTitle}}">
 <meta name="robots" content="noindex, nofollow">
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/img/icon/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/icon/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/icon/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{asset name='/img/icon/favicon-32x32.png'}}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{asset name='/img/icon/favicon-16x16.png'}}">
 <meta name="msapplication-config" content="none">
 <meta name="application-name" content="Nitro Example Page">
 <title>{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">
+<script defer src="{{asset name='/js/vendors.min.js'}}"></script>
+<script defer src="{{asset name='/js/ui.min.js'}}"></script>
+<script defer src="{{asset name='/js/proto.min.js'}}"></script>

--- a/packages/project-nitro/project/docs/nitro.md
+++ b/packages/project-nitro/project/docs/nitro.md
@@ -389,6 +389,8 @@ You may overwrite data from views & patterns in request parameters.
 
 ## Assets
 
+For final use, all assets are copied from the 'src' to the 'public' folder.
+
 ### Webpack
 
 The main assets will be bundled with an easy to use webpack config.
@@ -398,19 +400,29 @@ clientside handlebars, webfonts and images (with minification). It also includes
 
 You only have to enable the desired loaders and features. And of course, it is possible to extend the configuration to your needs.
 
-The configuration is placed in `/config/webpack`  
+The configuration is placed in '/config/webpack'  
 See [readme](./nitro-webpack.md) for configuration options.
 
 ### Other Assets
 
 Nitro also gives you some gulp tasks to use for additional assets you need in your build.
-You may copy assets, minify images or generate an svg sprites.
+You may copy assets, minify images or generate svg sprites.
 
-Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and [`gulpfile.js`](../../gulpfile.js)
+Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and ['gulpfile.js'](../../gulpfile.js)
 
 ### Prototype Assets
 
 Place [code for development](../../src/proto/readme.md) in the corresponding directories.
+
+### Asset helper
+
+The asset helper makes it possible to easily link your public assets in your markup.
+It can be used to change asset pathes depending on the environment.
+
+```
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+```
 
 ## Translations
 
@@ -460,10 +472,15 @@ To stay consistent you should favour the use of relative paths with a leading sl
 Link to resources relatively to the `project`-folder **with** a leading slash.
 
 ```html
-<link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
+<link rel="stylesheet" href="/assets/css/ui.min.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script defer src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.min.js"></script>
 <a href="/content">Contentpage</a>
+```
+
+...or use the 'asset' .hbs helper for public assets 
+```
+<link rel="stylesheet" href="{{asset name='/css/ui.min.css'}}" type="text/css" />
 ```
 
 ### Upper & lower case letters

--- a/packages/project-nitro/src/patterns/atoms/icon/icon.hbs
+++ b/packages/project-nitro/src/patterns/atoms/icon/icon.hbs
@@ -1,3 +1,3 @@
 <svg class="a-icon" xmlns="http://www.w3.org/2000/svg">
-	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svg/icons.svg#{{icon}}"></use>
+	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{asset name='/svg/icons.svg'}}#{{icon}}"></use>
 </svg>

--- a/packages/project-nitro/src/views/_partials/head.hbs
+++ b/packages/project-nitro/src/views/_partials/head.hbs
@@ -3,14 +3,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Nitro - {{_nitro.pageTitle}}">
 <meta name="robots" content="noindex, nofollow">
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/img/icon/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/icon/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/icon/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{asset name='/img/icon/favicon-32x32.png'}}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{asset name='/img/icon/favicon-16x16.png'}}">
 <meta name="msapplication-config" content="none">
 <meta name="application-name" content="Nitro Example Page">
 <title>{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">
+<script defer src="{{asset name='/js/vendors.min.js'}}"></script>
+<script defer src="{{asset name='/js/ui.min.js'}}"></script>
+<script defer src="{{asset name='/js/proto.min.js'}}"></script>

--- a/packages/project-nitro/src/views/_partials/test/head.hbs
+++ b/packages/project-nitro/src/views/_partials/test/head.hbs
@@ -4,12 +4,12 @@
 <meta name="description" content="">
 <meta name="robots" content="noindex, nofollow">
 
-<link rel="icon" href="/assets/img/icon/favicon.ico">
-<link rel="apple-touch-icon" href="/assets/img/icon/apple-touch-icon.png">
+<link rel="icon" href="{{asset name='/img/icon/favicon.ico'}}">
+<link rel="apple-touch-icon" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
 <meta name="application-name" content="Nitro">
 <meta name="msapplication-TileColor" content="#5133ab">
-<meta name="msapplication-TileImage" content="/assets/img/icon/tile-icon.png">
+<meta name="msapplication-TileImage" content="{{asset name='/img/icon/tile-icon.png'}}">
 
 <title>{{#if _nitro.production}}PRODUCTION: {{/if}}{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">

--- a/packages/project-prod/src/patterns/atoms/icon/icon.hbs
+++ b/packages/project-prod/src/patterns/atoms/icon/icon.hbs
@@ -1,3 +1,3 @@
 <svg class="a-icon" xmlns="http://www.w3.org/2000/svg">
-	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svg/icons.svg#{{icon}}"></use>
+	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{asset name='/svg/icons.svg'}}#{{icon}}"></use>
 </svg>

--- a/packages/project-prod/src/views/_partials/head.hbs
+++ b/packages/project-prod/src/views/_partials/head.hbs
@@ -3,14 +3,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Nitro - {{_nitro.pageTitle}}">
 <meta name="robots" content="noindex, nofollow">
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/img/icon/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/icon/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/icon/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{asset name='/img/icon/favicon-32x32.png'}}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{asset name='/img/icon/favicon-16x16.png'}}">
 <meta name="msapplication-config" content="none">
 <meta name="application-name" content="Nitro Example Page">
 <title>{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">
+<script defer src="{{asset name='/js/vendors.min.js'}}"></script>
+<script defer src="{{asset name='/js/ui.min.js'}}"></script>
+<script defer src="{{asset name='/js/proto.min.js'}}"></script>


### PR DESCRIPTION
## Purpose of this pull request? 

* Enhancement
* Documentation update

The pull request refers to the:

* generator (generator-nitro)
* nitro app (@nitro/app)
* example nitro projects (project-nitro & project-nitro-typescript)

## What changes did you make?

Add hbs helper 'asset' to the @nitro/app to make it easier to link assets in markup templates.

usage:

```
<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
```
