### PR TITLE
feat(project): add hbs asset helper

### DIFF
--- a/packages/generator-nitro/generators/app/templates/project/docs/nitro.md
+++ b/packages/generator-nitro/generators/app/templates/project/docs/nitro.md
@@ -404,6 +404,8 @@ You may overwrite data from views & patterns in request parameters.
 
 ## Assets
 
+For final use, all assets are copied from the 'src' to the 'public' folder.
+
 ### Webpack
 
 The main assets will be bundled with an easy to use webpack config.
@@ -413,19 +415,29 @@ clientside handlebars, webfonts and images (with minification). It also includes
 
 You only have to enable the desired loaders and features. And of course, it is possible to extend the configuration to your needs.
 
-The configuration is placed in `/config/webpack`  
+The configuration is placed in '/config/webpack'  
 See [readme](./nitro-webpack.md) for configuration options.
 
 ### Other Assets
 
 Nitro also gives you some gulp tasks to use for additional assets you need in your build.
-You may copy assets, minify images or generate an svg sprites.
+You may copy assets, minify images or generate svg sprites.
 
-Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and [`gulpfile.js`](../../gulpfile.js)
+Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and ['gulpfile.js'](../../gulpfile.js)
 
 ### Prototype Assets
 
-Place [code for development](../../src/proto/readme.md) in the corresponding directories.
+Place [code for development](../../src/proto/readme.md) in the corresponding directories.<% if (options.templateEngine !== 'twig') { %>
+
+### Asset helper
+
+The asset helper makes it possible to easily link your public assets in your markup.
+It can be used to change asset pathes depending on the environment.
+
+```
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+```<% } %>
 
 ## Translations
 
@@ -481,11 +493,16 @@ To stay consistent you should favour the use of relative paths with a leading sl
 Link to resources relatively to the `project`-folder **with** a leading slash.
 
 ```html
-<link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
+<link rel="stylesheet" href="/assets/css/ui.min.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script defer src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.min.js"></script>
 <a href="/content">Contentpage</a>
+```<% if (options.templateEngine !== 'twig') { %>
+
+...or use the 'asset' .hbs helper for public assets 
 ```
+<link rel="stylesheet" href="{{asset name='/css/ui.min.css'}}" type="text/css" />
+```<% } %>
 
 ### Upper & lower case letters
 

--- a/packages/generator-nitro/generators/app/templates/src/patterns/atoms/icon/icon.hbs
+++ b/packages/generator-nitro/generators/app/templates/src/patterns/atoms/icon/icon.hbs
@@ -1,3 +1,3 @@
 <svg class="a-icon" xmlns="http://www.w3.org/2000/svg">
-	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svg/icons.svg#{{icon}}"></use>
+	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{asset name='/svg/icons.svg'}}#{{icon}}"></use>
 </svg>

--- a/packages/generator-nitro/generators/app/templates/src/views/_partials/head.hbs
+++ b/packages/generator-nitro/generators/app/templates/src/views/_partials/head.hbs
@@ -3,14 +3,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Nitro - {{_nitro.pageTitle}}">
 <meta name="robots" content="noindex, nofollow"><% if (options.exampleCode) { %>
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/img/icon/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/icon/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/icon/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{asset name='/img/icon/favicon-32x32.png'}}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{asset name='/img/icon/favicon-16x16.png'}}">
 <meta name="msapplication-config" content="none">
 <meta name="application-name" content="Nitro Example Page"><% } %>
 <title>{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">
+<script defer src="{{asset name='/js/vendors.min.js'}}"></script>
+<script defer src="{{asset name='/js/ui.min.js'}}"></script>
+<script defer src="{{asset name='/js/proto.min.js'}}"></script>

--- a/packages/nitro-app/app/templating/hbs/helpers/asset.js
+++ b/packages/nitro-app/app/templating/hbs/helpers/asset.js
@@ -1,0 +1,28 @@
+/**
+ * asset helper, can be used to change asset pathes depending on the environment
+ * - prefix assets with the correct path of their environment
+ * - use minified version only on production environment
+ *
+ * Usage:
+ *
+ * {{asset name='/css/ui.min.css'}}
+ * (will load public/assets/css/ui.css on development environment)
+ *
+ * {{asset name='/img/icon/favicon-32x32.png'}}
+ */
+
+const hbs = require('hbs');
+const path = require('path');
+
+module.exports = function(context) {
+	const contextDataRoot = context.data && context.data.root ? context.data.root : {};
+	let name = context.hash.name;
+
+	// remove .min from asset on development environment
+	if (!contextDataRoot._nitro.production) {
+		name = name.replace(/\.min\./, '.');
+	}
+
+	const assetPath = path.join('/assets/', name).replace(/\\/g, '/');
+	return new hbs.SafeString(assetPath);
+};

--- a/packages/project-nitro-twig/project/docs/nitro.md
+++ b/packages/project-nitro-twig/project/docs/nitro.md
@@ -260,6 +260,7 @@ Render a partial (twig snippet). Partials are placed in `src/views/_partials/` a
 
 ```
 {% partial 'head' %}
+```
 
 ### Render placeholders
 
@@ -365,6 +366,8 @@ You may overwrite data from views & patterns in request parameters.
 
 ## Assets
 
+For final use, all assets are copied from the 'src' to the 'public' folder.
+
 ### Webpack
 
 The main assets will be bundled with an easy to use webpack config.
@@ -374,15 +377,15 @@ clientside handlebars, webfonts and images (with minification). It also includes
 
 You only have to enable the desired loaders and features. And of course, it is possible to extend the configuration to your needs.
 
-The configuration is placed in `/config/webpack`  
+The configuration is placed in '/config/webpack'  
 See [readme](./nitro-webpack.md) for configuration options.
 
 ### Other Assets
 
 Nitro also gives you some gulp tasks to use for additional assets you need in your build.
-You may copy assets, minify images or generate an svg sprites.
+You may copy assets, minify images or generate svg sprites.
 
-Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and [`gulpfile.js`](../../gulpfile.js)
+Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and ['gulpfile.js'](../../gulpfile.js)
 
 ### Prototype Assets
 
@@ -435,9 +438,9 @@ To stay consistent you should favour the use of relative paths with a leading sl
 Link to resources relatively to the `project`-folder **with** a leading slash.
 
 ```html
-<link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
+<link rel="stylesheet" href="/assets/css/ui.min.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script defer src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.min.js"></script>
 <a href="/content">Contentpage</a>
 ```
 

--- a/packages/project-nitro-typescript/project/docs/nitro.md
+++ b/packages/project-nitro-typescript/project/docs/nitro.md
@@ -389,6 +389,8 @@ You may overwrite data from views & patterns in request parameters.
 
 ## Assets
 
+For final use, all assets are copied from the 'src' to the 'public' folder.
+
 ### Webpack
 
 The main assets will be bundled with an easy to use webpack config.
@@ -398,19 +400,29 @@ clientside handlebars, webfonts and images (with minification). It also includes
 
 You only have to enable the desired loaders and features. And of course, it is possible to extend the configuration to your needs.
 
-The configuration is placed in `/config/webpack`  
+The configuration is placed in '/config/webpack'  
 See [readme](./nitro-webpack.md) for configuration options.
 
 ### Other Assets
 
 Nitro also gives you some gulp tasks to use for additional assets you need in your build.
-You may copy assets, minify images or generate an svg sprites.
+You may copy assets, minify images or generate svg sprites.
 
-Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and [`gulpfile.js`](../../gulpfile.js)
+Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and ['gulpfile.js'](../../gulpfile.js)
 
 ### Prototype Assets
 
 Place [code for development](../../src/proto/readme.md) in the corresponding directories.
+
+### Asset helper
+
+The asset helper makes it possible to easily link your public assets in your markup.
+It can be used to change asset pathes depending on the environment.
+
+```
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+```
 
 ## Translations
 
@@ -460,10 +472,15 @@ To stay consistent you should favour the use of relative paths with a leading sl
 Link to resources relatively to the `project`-folder **with** a leading slash.
 
 ```html
-<link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
+<link rel="stylesheet" href="/assets/css/ui.min.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script defer src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.min.js"></script>
 <a href="/content">Contentpage</a>
+```
+
+...or use the 'asset' .hbs helper for public assets 
+```
+<link rel="stylesheet" href="{{asset name='/css/ui.min.css'}}" type="text/css" />
 ```
 
 ### Upper & lower case letters

--- a/packages/project-nitro-typescript/src/patterns/atoms/icon/icon.hbs
+++ b/packages/project-nitro-typescript/src/patterns/atoms/icon/icon.hbs
@@ -1,3 +1,3 @@
 <svg class="a-icon" xmlns="http://www.w3.org/2000/svg">
-	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svg/icons.svg#{{icon}}"></use>
+	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{asset name='/svg/icons.svg'}}#{{icon}}"></use>
 </svg>

--- a/packages/project-nitro-typescript/src/views/_partials/head.hbs
+++ b/packages/project-nitro-typescript/src/views/_partials/head.hbs
@@ -3,14 +3,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Nitro - {{_nitro.pageTitle}}">
 <meta name="robots" content="noindex, nofollow">
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/img/icon/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/icon/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/icon/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{asset name='/img/icon/favicon-32x32.png'}}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{asset name='/img/icon/favicon-16x16.png'}}">
 <meta name="msapplication-config" content="none">
 <meta name="application-name" content="Nitro Example Page">
 <title>{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">
+<script defer src="{{asset name='/js/vendors.min.js'}}"></script>
+<script defer src="{{asset name='/js/ui.min.js'}}"></script>
+<script defer src="{{asset name='/js/proto.min.js'}}"></script>

--- a/packages/project-nitro/project/docs/nitro.md
+++ b/packages/project-nitro/project/docs/nitro.md
@@ -389,6 +389,8 @@ You may overwrite data from views & patterns in request parameters.
 
 ## Assets
 
+For final use, all assets are copied from the 'src' to the 'public' folder.
+
 ### Webpack
 
 The main assets will be bundled with an easy to use webpack config.
@@ -398,19 +400,29 @@ clientside handlebars, webfonts and images (with minification). It also includes
 
 You only have to enable the desired loaders and features. And of course, it is possible to extend the configuration to your needs.
 
-The configuration is placed in `/config/webpack`  
+The configuration is placed in '/config/webpack'  
 See [readme](./nitro-webpack.md) for configuration options.
 
 ### Other Assets
 
 Nitro also gives you some gulp tasks to use for additional assets you need in your build.
-You may copy assets, minify images or generate an svg sprites.
+You may copy assets, minify images or generate svg sprites.
 
-Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and [`gulpfile.js`](../../gulpfile.js)
+Configuration for gulp tasks is done in [config package](../../config/default/gulp.js) and ['gulpfile.js'](../../gulpfile.js)
 
 ### Prototype Assets
 
 Place [code for development](../../src/proto/readme.md) in the corresponding directories.
+
+### Asset helper
+
+The asset helper makes it possible to easily link your public assets in your markup.
+It can be used to change asset pathes depending on the environment.
+
+```
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+```
 
 ## Translations
 
@@ -460,10 +472,15 @@ To stay consistent you should favour the use of relative paths with a leading sl
 Link to resources relatively to the `project`-folder **with** a leading slash.
 
 ```html
-<link rel="stylesheet" href="/assets/css/ui.css" type="text/css" />
+<link rel="stylesheet" href="/assets/css/ui.min.css" type="text/css" />
 <link rel="shortcut icon" href="/assets/img/icon/favicon.ico" type="image/x-icon" />
-<script defer src="/assets/js/ui.js"></script>
+<script defer src="/assets/js/ui.min.js"></script>
 <a href="/content">Contentpage</a>
+```
+
+...or use the 'asset' .hbs helper for public assets 
+```
+<link rel="stylesheet" href="{{asset name='/css/ui.min.css'}}" type="text/css" />
 ```
 
 ### Upper & lower case letters

--- a/packages/project-nitro/src/patterns/atoms/icon/icon.hbs
+++ b/packages/project-nitro/src/patterns/atoms/icon/icon.hbs
@@ -1,3 +1,3 @@
 <svg class="a-icon" xmlns="http://www.w3.org/2000/svg">
-	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svg/icons.svg#{{icon}}"></use>
+	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{asset name='/svg/icons.svg'}}#{{icon}}"></use>
 </svg>

--- a/packages/project-nitro/src/patterns/test/ico/ico.hbs
+++ b/packages/project-nitro/src/patterns/test/ico/ico.hbs
@@ -1,3 +1,3 @@
 <svg class="t-ico" xmlns="http://www.w3.org/2000/svg">
-	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svg/icos.svg#{{icon}}"></use>
+	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{asset name='/svg/icos.svg'}}#{{icon}}"></use>
 </svg>

--- a/packages/project-nitro/src/views/_partials/head.hbs
+++ b/packages/project-nitro/src/views/_partials/head.hbs
@@ -3,14 +3,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Nitro - {{_nitro.pageTitle}}">
 <meta name="robots" content="noindex, nofollow">
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/img/icon/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/icon/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/icon/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{asset name='/img/icon/favicon-32x32.png'}}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{asset name='/img/icon/favicon-16x16.png'}}">
 <meta name="msapplication-config" content="none">
 <meta name="application-name" content="Nitro Example Page">
 <title>{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">
+<script defer src="{{asset name='/js/vendors.min.js'}}"></script>
+<script defer src="{{asset name='/js/ui.min.js'}}"></script>
+<script defer src="{{asset name='/js/proto.min.js'}}"></script>

--- a/packages/project-nitro/src/views/_partials/test/foot.hbs
+++ b/packages/project-nitro/src/views/_partials/test/foot.hbs
@@ -1,5 +1,5 @@
-<script src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+<script src="{{asset name='/js/vendors.min.js'}}"></script>
+<script src="{{asset name='/js/ui.min.js'}}"></script>
+<script src="{{asset name='/js/proto.min.js'}}"></script>
 
 <p>{{_nitro.pageTitle}} = pageTitle (view)</p>

--- a/packages/project-nitro/src/views/_partials/test/head.hbs
+++ b/packages/project-nitro/src/views/_partials/test/head.hbs
@@ -4,12 +4,12 @@
 <meta name="description" content="">
 <meta name="robots" content="noindex, nofollow">
 
-<link rel="icon" href="/assets/img/icon/favicon.ico">
-<link rel="apple-touch-icon" href="/assets/img/icon/apple-touch-icon.png">
+<link rel="icon" href="{{asset name='/img/icon/favicon.ico'}}">
+<link rel="apple-touch-icon" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
 <meta name="application-name" content="Nitro">
 <meta name="msapplication-TileColor" content="#5133ab">
-<meta name="msapplication-TileImage" content="/assets/img/icon/tile-icon.png">
+<meta name="msapplication-TileImage" content="{{asset name='/img/icon/tile-icon.png'}}">
 
 <title>{{#if _nitro.production}}PRODUCTION: {{/if}}{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">

--- a/packages/project-prod/src/patterns/atoms/icon/icon.hbs
+++ b/packages/project-prod/src/patterns/atoms/icon/icon.hbs
@@ -1,3 +1,3 @@
 <svg class="a-icon" xmlns="http://www.w3.org/2000/svg">
-	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svg/icons.svg#{{icon}}"></use>
+	<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{asset name='/svg/icons.svg'}}#{{icon}}"></use>
 </svg>

--- a/packages/project-prod/src/views/_partials/head.hbs
+++ b/packages/project-prod/src/views/_partials/head.hbs
@@ -3,14 +3,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Nitro - {{_nitro.pageTitle}}">
 <meta name="robots" content="noindex, nofollow">
-<link rel="apple-touch-icon" sizes="180x180" href="/assets/img/icon/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/icon/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/icon/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="{{asset name='/img/icon/apple-touch-icon.png'}}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{asset name='/img/icon/favicon-32x32.png'}}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{asset name='/img/icon/favicon-16x16.png'}}">
 <meta name="msapplication-config" content="none">
 <meta name="application-name" content="Nitro Example Page">
 <title>{{_nitro.pageTitle}}</title>
-<link href="/assets/css/ui{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<link href="/assets/css/proto{{#if _nitro.production}}.min{{/if}}.css" rel="stylesheet">
-<script defer src="/assets/js/vendors{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/ui{{#if _nitro.production}}.min{{/if}}.js"></script>
-<script defer src="/assets/js/proto{{#if _nitro.production}}.min{{/if}}.js"></script>
+<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
+<link href="{{asset name='/css/proto.min.css'}}" rel="stylesheet">
+<script defer src="{{asset name='/js/vendors.min.js'}}"></script>
+<script defer src="{{asset name='/js/ui.min.js'}}"></script>
+<script defer src="{{asset name='/js/proto.min.js'}}"></script>


### PR DESCRIPTION
## Purpose of this pull request? 

* Enhancement
* Documentation update

The pull request refers to the:

* generator (generator-nitro)
* nitro app (@nitro/app)
* example nitro projects (project-nitro & project-nitro-typescript)

## What changes did you make?

Add hbs helper 'asset' to the @nitro/app to make it easier to link assets in markup templates.

usage:

```
<link href="{{asset name='/css/ui.min.css'}}" rel="stylesheet">
```
this will load 'public/assets/css/ui.css' on development env
and 'public/assets/css/ui..min.css' on production env