### PR TITLE
Use hash for CSS chunks

### DIFF
--- a/packages/nitro-webpack/webpack-config/webpack.config.prod.js
+++ b/packages/nitro-webpack/webpack-config/webpack.config.prod.js
@@ -159,7 +159,7 @@ module.exports = (options = { rules: {}, features: {} }) => {
 		webpackConfig.plugins.push(
 			new MiniCssExtractPlugin({
 				filename: 'css/[name].min.css',
-				chunkFilename: 'css/[name]-[id].min.css',
+				chunkFilename: 'css/[name]-[contenthash:7].min.css',
 			}),
 			new OptimizeCSSAssetsPlugin({
 				cssProcessorOptions: {


### PR DESCRIPTION
In our application we had some cache hits on changed files which delivered outdated CSS to our users. Using the a hash instead of the id in the name of the asset should fix this.

I'm not sure if this has any bigger impact on the whole nitro setup though 🙃