### PR TITLE
feat(project): enhance svg sprites to support array as src #180

### DIFF
--- a/packages/generator-nitro/generators/app/templates/project/docs/nitro-config.md
+++ b/packages/generator-nitro/generators/app/templates/project/docs/nitro-config.md
@@ -256,12 +256,12 @@ Object Properties:
 
 Type: Array of Objects
 
-Generates icon sprite with the name of the last folder in src
+Generates icon sprite with the name of the last folder in src. If src is an array, it uses the last folder from the first entry.
 
 Properties:
 
--   `gulp.svgSprites.src` Sting (default: ''; example: 'src/patterns/atoms/icon/img/icons/\*.svg')
--   `gulp.svgSprites.dest` Sting (default: ''; example: 'public/assets/svg')
+-   `gulp.svgSprites.src` String || String[] (default: ''; example: 'src/patterns/atoms/icon/img/icons/\*.svg')
+-   `gulp.svgSprites.dest` String (default: ''; example: 'public/assets/svg')
 
 ## Feature
 

--- a/packages/nitro-gulp/tasks/watch-assets.js
+++ b/packages/nitro-gulp/tasks/watch-assets.js
@@ -24,7 +24,7 @@ module.exports = (gulp) => {
 		const minifyImagesSrc = config.has('gulp.minifyImages') ?
 			config.get('gulp.minifyImages').map(o => o.src).filter(Boolean) : [];
 		const svgSpritesSrc = config.has('gulp.svgSprites') ?
-			config.get('gulp.svgSprites').map(o => o.src).filter(Boolean) : [];
+			config.get('gulp.svgSprites').flatMap(o => o.src).filter(Boolean) : [];
 
 		if (config.get('nitro.mode.livereload')) {
 			gulp.watch([

--- a/packages/project-nitro-twig/project/docs/nitro-config.md
+++ b/packages/project-nitro-twig/project/docs/nitro-config.md
@@ -256,11 +256,11 @@ Object Properties:
 
 Type: Array of Objects
 
-Generates icon sprite with the name of the last folder in src
+Generates icon sprite with the name of the last folder in src. If src is an array, it uses the last folder from the first entry.
 
 Properties:
 
--   `gulp.svgSprites.src` String (default: ''; example: 'src/patterns/atoms/icon/img/icons/\*.svg')
+-   `gulp.svgSprites.src` String || String[] (default: ''; example: 'src/patterns/atoms/icon/img/icons/\*.svg')
 -   `gulp.svgSprites.dest` String (default: ''; example: 'public/assets/svg')
 
 ## Feature

--- a/packages/project-nitro-typescript/project/docs/nitro-config.md
+++ b/packages/project-nitro-typescript/project/docs/nitro-config.md
@@ -256,11 +256,11 @@ Object Properties:
 
 Type: Array of Objects
 
-Generates icon sprite with the name of the last folder in src
+Generates icon sprite with the name of the last folder in src. If src is an array, it uses the last folder from the first entry.
 
 Properties:
 
--   `gulp.svgSprites.src` String (default: ''; example: 'src/patterns/atoms/icon/img/icons/\*.svg')
+-   `gulp.svgSprites.src` String || String[] (default: ''; example: 'src/patterns/atoms/icon/img/icons/\*.svg')
 -   `gulp.svgSprites.dest` String (default: ''; example: 'public/assets/svg')
 
 ## Feature

--- a/packages/project-nitro/project/docs/nitro-config.md
+++ b/packages/project-nitro/project/docs/nitro-config.md
@@ -256,11 +256,11 @@ Object Properties:
 
 Type: Array of Objects
 
-Generates icon sprite with the name of the last folder in src
+Generates icon sprite with the name of the last folder in src. If src is an array, it uses the last folder from the first entry.
 
 Properties:
 
--   `gulp.svgSprites.src` String (default: ''; example: 'src/patterns/atoms/icon/img/icons/\*.svg')
+-   `gulp.svgSprites.src` String || String[] (default: ''; example: 'src/patterns/atoms/icon/img/icons/\*.svg')
 -   `gulp.svgSprites.dest` String (default: ''; example: 'public/assets/svg')
 
 ## Feature


### PR DESCRIPTION
## Purpose of this pull request? 

* Enhancement

The pull request refers to the:

* nitro gulp tasks (@nitro/gulp)

## What changes did you make?

Enhance svg sprites task to take an array as src to be able to have multiple icon src folders to be compiled to one single svg sprites file
