### PR TITLE
feat(project): adjust typo definitions to have typo bundle as first level

### DIFF
--- a/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
+++ b/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
@@ -1,6 +1,6 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-family-sans: Arial, sans-serif;
+$typography-family-sans: 'Arial', sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
 $typography-weight-bold: 700;

--- a/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
+++ b/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
@@ -1,98 +1,103 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-default-family: 'minion';
-$typography-default-size: 'm';
+$typography-default-family: 'sans';
+$typography-default-size: 'sans-m';
 $typography-default-style: null;
 
 $typography-normal-ascender: 0.225rem;
 
-$typography-definition-mobile: (
-	sans: (
-		s: (
+$typography-size-definition: (
+	sans-s: (
+		mobile: (
 			'font-size': 17px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
-		m: (
+		desktop: (
+			'font-size': 21px,
+			'line-height': 32px,
+			'letter-spacing': 0.75px
+		)
+	),
+	sans-m: (
+		mobile: (
 			'font-size': 18px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
-		l: (
+		desktop: (
 			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		xl: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		xxl: (
-			'font-size': 26px,
 			'line-height': 32px,
-			'letter-spacing': 0.3px
-		),
-		xxxl: (
-			'font-size': 32px,
-			'line-height': 40px,
 			'letter-spacing': 0.5px
 		)
 	),
-	serif: (
-		s: (
-			'font-size': 14px,
-			'line-height': 20px,
-			'letter-spacing': 0.3px
-		),
-		m: (
-			'font-size': 16px,
-			'line-height': 24px,
-			'letter-spacing': 0.3px
-		),
-	)
-);
-
-$typography-definition-desktop: (
-	sans: (
-		s: (
-			'font-size': 21px,
-			'line-height': 32px,
-			'letter-spacing': 0.75px
-		),
-		m: (
+	sans-l: (
+		mobile: (
 			'font-size': 22px,
-			'line-height': 32px,
-			'letter-spacing': 0.5px
+			'line-height': 28px,
+			'letter-spacing': 0.3px
 		),
-		l: (
+		desktop: (
 			'font-size': 26px,
 			'line-height': 32px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xl: (
+		mobile: (
+			'font-size': 22px,
+			'line-height': 28px,
+			'letter-spacing': 0.3px
 		),
-		xl: (
+		desktop: (
 			'font-size': 26px,
 			'line-height': 36px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xxl: (
+		mobile: (
+			'font-size': 26px,
+			'line-height': 32px,
+			'letter-spacing': 0.3px
 		),
-		xxl: (
+		desktop: (
 			'font-size': 34px,
 			'line-height': 44px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xxxl: (
+		mobile: (
+			'font-size': 32px,
+			'line-height': 40px,
+			'letter-spacing': 0.5px
 		),
-		xxxl: (
+		desktop: (
 			'font-size': 50px,
 			'line-height': 64px,
 			'letter-spacing': 1px
 		)
 	),
-	serif: (
-		s: (
+	serif-s: (
+		mobile: (
 			'font-size': 14px,
 			'line-height': 20px,
 			'letter-spacing': 0.3px
 		),
-		m: (
+		desktop: (
+			'font-size': 14px,
+			'line-height': 20px,
+			'letter-spacing': 0.3px
+		)
+	),
+	serif-m: (
+		mobile: (
+			'font-size': 16px,
+			'line-height': 24px,
+			'letter-spacing': 0.3px
+		),
+		desktop: (
 			'font-size': 16px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
@@ -100,34 +105,15 @@ $typography-definition-desktop: (
 	)
 );
 
+$typography-definition-mobile: ();
+
+$typography-definition-desktop: ();
+
 /*
 	Functions to get the definition
 */
 
-@function typography-get-definition($breakpoint) {
-	@if ($breakpoint == 'mobile') {
-		@return $typography-definition-mobile;
-	}
-	@if ($breakpoint == 'desktop') {
-		@return $typography-definition-desktop;
-	}
-	@warn 'Unknown typography breakpoint '#{$breakpoint}'.';
-}
-
-@function typography-get-font-definition($breakpoint, $size, $family) {
-	$typography-breakpoint: typography-get-definition($breakpoint);
-	$typography-family: map-get($typography-breakpoint, $family);
-	@if ($typography-family == null) {
-		@warn 'Unknown typography definition for breakpoint '#{$breakpoint}' and family '#{$family}'.';
-	}
-	$typography-font-definition: map-get($typography-family, $size);
-	@if ($typography-font-definition == null) {
-		@warn 'Unknown typography definition for breakpoint '#{$breakpoint}', family '#{$family}' and size #{$size}.';
-	}
-	@return $typography-font-definition;
-}
-
-@mixin getDefinition($font-definition, $style, $family) {
+@mixin generate-font-styles($font-definition, $family, $style) {
 	font-size: map-get($font-definition, 'font-size');
 	line-height: map-get($font-definition, 'line-height');
 	letter-spacing: map-get($font-definition, 'letter-spacing');
@@ -145,34 +131,45 @@ $typography-definition-desktop: (
 		}
 	}
 	@if($family == 'serif') {
-		font-family: Arial, sans-serif;
+		font-family: 'Times New Roman', serif;
 
-		@if ($style == 'serif') {
-			font-family: Arial, sans-serif;
+		@if ($style == 'bold') {
+			font-family: 'Times New Roman', serif;
+			font-weight: bold;
 		}
-		@if ($style == 'semi-bold') {
-			font-family: Arial, sans-serif;
+		@if ($style == 'italic') {
+			font-family: 'Times New Roman', serif;
+			font-style: italic;
 		}
 	}
+}
+
+// Return the font definition for the given viewport and font-name
+@function get-font-definition($fontSize, $viewport) {
+	@if (not(map-has-key($typography-size-definition, $fontSize))) {
+		@error 'Typography font name `#{$fontSize}` does not exist.';
+	} @else if (not(map-has-key(map-get($typography-size-definition, $fontSize), $viewport))) {
+		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$fontSize}`.';
+	}
+
+	$font-definition: map-get(map-get($typography-size-definition, $fontSize), $viewport);
+
+	@return $font-definition;
 }
 
 /*
 	mixin to use in the code
 
 	Params:
-		- $size: gets the typo definition according to the size (e.g. s, m, l)
-		- $style: defines the style of the font. Accepted Values are 'bold', 'italic', 'semi-bold'. Default is null
-		- $family: defines the family of the language. Currently is minion default.
-		- $margin-bottom: adds a calculated margin at the bottom.
+		- $size: gets the typo definition according to the size (e.g. sans-s, sans-m, sans-l)
+		- $style: defines the style of the font. Accepted Values are 'bold', 'italic'. Default is null
+		- $family: defines the family of the language. Currently is sans default.
 */
 
-@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, $margin-bottom: 0) {
-
-	$font-definition: typography-get-font-definition('mobile', $size, $family);
-	@include getDefinition($font-definition, $style, $family);
+@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, ) {
+	@include generate-font-styles(get-font-definition($size, 'mobile'), $style, $family);
 
 	@media screen and (min-width: $size-md-min) {
-		$font-definition: typography-get-font-definition('desktop', $size, $family);
-		@include getDefinition($font-definition, $style, $family);
+		@include generate-font-styles(get-font-definition($size, 'desktop'), $style, $family);
 	}
 }

--- a/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
+++ b/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
@@ -3,6 +3,9 @@
 $typography-family-sans: Arial, sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
+$typography-weight-bold: 700;
+$typography-style-italic: italic;
+
 $typography-definitions: (
 	default: (
 		base: (
@@ -11,24 +14,6 @@ $typography-definitions: (
 			'font-family': $typography-family-sans,
 			'font-weight': 400,
 			'font-style': normal,
-		),
-	),
-	font-family: (
-		title: (
-			'font-family': $typography-family-sans,
-		),
-		text: (
-			'font-family': $typography-family-sans,
-		),
-	),
-	font-weight: (
-		bold: (
-			'font-weight': 700,
-		),
-	),
-	font-style: (
-		italic: (
-			'font-style': italic,
 		),
 	),
 	body: (
@@ -64,6 +49,7 @@ $typography-definitions: (
 	h1: (
 		all: (
 			'font-family': $typography-family-serif,
+			'font-font-weight': $typography-weight-bold,
 		),
 		mobile: (
 			'font-size': 32px,
@@ -79,6 +65,7 @@ $typography-definitions: (
 	h2: (
 		all: (
 			'font-family': $typography-family-serif,
+			'font-style': $typography-style-italic,
 		),
 		mobile: (
 			'font-size': 24px,
@@ -152,7 +139,7 @@ $typography-definitions: (
 	@if ($viewport == 'all') {
 		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));
 
-		@media screen and (min-width: $size-md-min) {
+		@media (min-width: $size-md-min) {
 			@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'desktop'));
 		}
 	} @else {

--- a/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
+++ b/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
@@ -1,13 +1,40 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-default-family: 'sans';
-$typography-default-size: 'sans-m';
-$typography-default-style: null;
-
-$typography-normal-ascender: 0.225rem;
+$typography-family-sans: Arial, sans-serif;
+$typography-family-serif: 'Times New Roman', serif;
 
 $typography-size-definition: (
+	default: (
+		base: (
+			'font-size': 1.6rem,
+			'line-height': 1,
+			'font-family': $typography-family-sans,
+			'font-weight': 400,
+			'font-style': normal,
+		),
+	),
+	font-family: (
+		title: (
+			'font-family': $typography-family-sans,
+		),
+		text: (
+			'font-family': $typography-family-sans,
+		),
+	),
+	font-weight: (
+		bold: (
+			'font-weight': 700,
+		),
+	),
+	font-style: (
+		italic: (
+			'font-style': italic,
+		),
+	),
 	sans-s: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 17px,
 			'line-height': 24px,
@@ -20,6 +47,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-m: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 18px,
 			'line-height': 24px,
@@ -32,6 +62,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-l: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 22px,
 			'line-height': 28px,
@@ -44,6 +77,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 22px,
 			'line-height': 28px,
@@ -56,6 +92,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xxl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 26px,
 			'line-height': 32px,
@@ -68,6 +107,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xxxl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 32px,
 			'line-height': 40px,
@@ -80,6 +122,9 @@ $typography-size-definition: (
 		)
 	),
 	serif-s: (
+		all: (
+			'font-family': $typography-family-serif,
+		),
 		mobile: (
 			'font-size': 14px,
 			'line-height': 20px,
@@ -92,6 +137,9 @@ $typography-size-definition: (
 		)
 	),
 	serif-m: (
+		all: (
+			'font-family': $typography-family-serif,
+		),
 		mobile: (
 			'font-size': 16px,
 			'line-height': 24px,
@@ -105,71 +153,57 @@ $typography-size-definition: (
 	)
 );
 
-$typography-definition-mobile: ();
+// Output generation for font-size definition
+@mixin _generate-font-size($font-size-definition) {
+	font-size: map-get($font-size-definition, 'font-size');
+	line-height: map-get($font-size-definition, 'line-height');
 
-$typography-definition-desktop: ();
-
-/*
-	Functions to get the definition
-*/
-
-@mixin generate-font-styles($font-definition, $family, $style) {
-	font-size: map-get($font-definition, 'font-size');
-	line-height: map-get($font-definition, 'line-height');
-	letter-spacing: map-get($font-definition, 'letter-spacing');
-
-	@if($family == 'sans') {
-		font-family: Arial, sans-serif;
-
-		@if ($style == 'bold') {
-			font-family: Arial, sans-serif;
-			font-weight: bold;
-		}
-		@if ($style == 'italic') {
-			font-family: Arial, sans-serif;
-			font-style: italic;
-		}
+	@if (map-has-key($font-size-definition, 'font-family')) {
+		font-family: map-get($font-size-definition, 'font-family');
 	}
-	@if($family == 'serif') {
-		font-family: 'Times New Roman', serif;
-
-		@if ($style == 'bold') {
-			font-family: 'Times New Roman', serif;
-			font-weight: bold;
-		}
-		@if ($style == 'italic') {
-			font-family: 'Times New Roman', serif;
-			font-style: italic;
-		}
+	@if (map-has-key($font-size-definition, 'font-weight')) {
+		font-weight: map-get($font-size-definition, 'font-weight');
+	}
+	@if (map-has-key($font-size-definition, 'font-style')) {
+		font-style: map-get($font-size-definition, 'font-style');
+	}
+	@if (map-has-key($font-size-definition, 'letter-spacing')) {
+		letter-spacing: map-get($font-size-definition, 'letter-spacing');
+	}
+	@if (map-has-key($font-size-definition, 'text-transform')) {
+		text-transform: map-get($font-size-definition, 'text-transform');
 	}
 }
 
 // Return the font definition for the given viewport and font-name
-@function get-font-definition($fontSize, $viewport) {
-	@if (not(map-has-key($typography-size-definition, $fontSize))) {
-		@error 'Typography font name `#{$fontSize}` does not exist.';
-	} @else if (not(map-has-key(map-get($typography-size-definition, $fontSize), $viewport))) {
-		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$fontSize}`.';
+@function get-font-definition($font-bundle, $viewport) {
+	@if (not(map-has-key($typography-size-definition, $font-bundle))) {
+		@error 'Typography font name `#{$font-bundle}` does not exist.';
+	} @else if (not(map-has-key(map-get($typography-size-definition, $font-bundle), $viewport))) {
+		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$font-bundle}`.';
 	}
 
-	$font-definition: map-get(map-get($typography-size-definition, $fontSize), $viewport);
+	$all-font-definition: ();
+	@if (map-has-key(map-get($typography-size-definition, $font-bundle), 'all')) {
+		$all-font-definition: map-get(map-get($typography-size-definition, $font-bundle), 'all');
+	}
+	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-size-definition, $font-bundle), $viewport));
 
 	@return $font-definition;
 }
 
-/*
-	mixin to use in the code
+// Returns a (responsive) typography for the given font name
+// Usage:
+// span { @include typography('body') }
+// span { @include typography('body', 'md') }
+@mixin typography($font-bundle, $viewport: 'all') {
+	@if ($viewport == 'all') {
+		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));
 
-	Params:
-		- $size: gets the typo definition according to the size (e.g. sans-s, sans-m, sans-l)
-		- $style: defines the style of the font. Accepted Values are 'bold', 'italic'. Default is null
-		- $family: defines the family of the language. Currently is sans default.
-*/
-
-@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, ) {
-	@include generate-font-styles(get-font-definition($size, 'mobile'), $style, $family);
-
-	@media screen and (min-width: $size-md-min) {
-		@include generate-font-styles(get-font-definition($size, 'desktop'), $style, $family);
+		@media screen and (min-width: $size-md-min) {
+			@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'desktop'));
+		}
+	} @else {
+		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: $viewport));
 	}
 }

--- a/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
+++ b/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/css/typo.scss
@@ -3,7 +3,7 @@
 $typography-family-sans: Arial, sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
-$typography-size-definition: (
+$typography-definitions: (
 	default: (
 		base: (
 			'font-size': 1.6rem,
@@ -31,126 +31,81 @@ $typography-size-definition: (
 			'font-style': italic,
 		),
 	),
-	sans-s: (
+	body: (
 		all: (
 			'font-family': $typography-family-sans,
 		),
 		mobile: (
-			'font-size': 17px,
+			'font-size': 16px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 21px,
+			'font-size': 24px,
 			'line-height': 32px,
 			'letter-spacing': 0.75px
 		)
 	),
-	sans-m: (
+	body-small: (
 		all: (
 			'font-family': $typography-family-sans,
 		),
 		mobile: (
-			'font-size': 18px,
+			'font-size': 12px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 22px,
+			'font-size': 18px,
 			'line-height': 32px,
-			'letter-spacing': 0.5px
+			'letter-spacing': 0.75px
 		)
 	),
-	sans-l: (
+	h1: (
 		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 26px,
-			'line-height': 32px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xl: (
-		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 26px,
-			'line-height': 36px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xxl: (
-		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 26px,
-			'line-height': 32px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 34px,
-			'line-height': 44px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xxxl: (
-		all: (
-			'font-family': $typography-family-sans,
+			'font-family': $typography-family-serif,
 		),
 		mobile: (
 			'font-size': 32px,
-			'line-height': 40px,
-			'letter-spacing': 0.5px
+			'line-height': 44px,
+			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 50px,
-			'line-height': 64px,
-			'letter-spacing': 1px
+			'font-size': 44px,
+			'line-height': 56px,
+			'letter-spacing': 0.3px
 		)
 	),
-	serif-s: (
+	h2: (
 		all: (
 			'font-family': $typography-family-serif,
 		),
 		mobile: (
-			'font-size': 14px,
-			'line-height': 20px,
+			'font-size': 24px,
+			'line-height': 32px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 14px,
-			'line-height': 20px,
+			'font-size': 32px,
+			'line-height': 44px,
 			'letter-spacing': 0.3px
 		)
 	),
-	serif-m: (
+	button: (
 		all: (
 			'font-family': $typography-family-serif,
 		),
 		mobile: (
-			'font-size': 16px,
-			'line-height': 24px,
+			'font-size': 18px,
+			'line-height': 18px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 16px,
-			'line-height': 24px,
+			'font-size': 20px,
+			'line-height': 20px,
 			'letter-spacing': 0.3px
 		)
-	)
+	),
 );
 
 // Output generation for font-size definition
@@ -177,25 +132,22 @@ $typography-size-definition: (
 
 // Return the font definition for the given viewport and font-name
 @function get-font-definition($font-bundle, $viewport) {
-	@if (not(map-has-key($typography-size-definition, $font-bundle))) {
+	@if (not(map-has-key($typography-definitions, $font-bundle))) {
 		@error 'Typography font name `#{$font-bundle}` does not exist.';
-	} @else if (not(map-has-key(map-get($typography-size-definition, $font-bundle), $viewport))) {
+	} @else if (not(map-has-key(map-get($typography-definitions, $font-bundle), $viewport))) {
 		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$font-bundle}`.';
 	}
 
 	$all-font-definition: ();
-	@if (map-has-key(map-get($typography-size-definition, $font-bundle), 'all')) {
-		$all-font-definition: map-get(map-get($typography-size-definition, $font-bundle), 'all');
+	@if (map-has-key(map-get($typography-definitions, $font-bundle), 'all')) {
+		$all-font-definition: map-get(map-get($typography-definitions, $font-bundle), 'all');
 	}
-	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-size-definition, $font-bundle), $viewport));
+	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-definitions, $font-bundle), $viewport));
 
 	@return $font-definition;
 }
 
-// Returns a (responsive) typography for the given font name
-// Usage:
-// span { @include typography('body') }
-// span { @include typography('body', 'md') }
+// Render a set of typography styles for one or all defined viewports
 @mixin typography($font-bundle, $viewport: 'all') {
 	@if ($viewport == 'all') {
 		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));

--- a/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/readme.md
+++ b/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/readme.md
@@ -1,8 +1,10 @@
 # Typo
 
-> Typography util
+> Typography util which returns a set of typography styles for one or all defined viewports 
 
 ## Usage
+
+Please note: depending on the number of viewports, the output bundle size might get a bit large!
 
 ### typography mixin
 
@@ -11,8 +13,8 @@ Writes desired typography definition.
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('sans-s') }
-span { @include typography('serif-m') }
+span { @include typography('body') }
+span { @include typography('h1') }
 ```
 
 Or use a second parameter !== 'all' to only import the definition for specific viewport:
@@ -20,7 +22,7 @@ Or use a second parameter !== 'all' to only import the definition for specific v
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('sans-s', 'md') }
+span { @include typography('h2', 'md') }
 ```
 
 Or use the font-family / font-weight / font-style properties to just get single properties:
@@ -35,7 +37,7 @@ span { @include typography('font-style', 'italic') }
 
 ### get-font-definition function
 
-Returns a font definiton map from a specific viewport
+Returns a font definition map from a specific viewport
 
 ```
 @import 'src/shared/utils/typo/css/typo';

--- a/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/readme.md
+++ b/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/readme.md
@@ -1,0 +1,44 @@
+# Typo
+
+> Typography util
+
+## Usage
+
+### typography mixin
+
+Writes desired typography definition.
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('sans-s') }
+span { @include typography('serif-m') }
+```
+
+Or use a second parameter !== 'all' to only import the definition for specific viewport:
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('sans-s', 'md') }
+```
+
+Or use the font-family / font-weight / font-style properties to just get single properties:
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('font-family', 'text') }
+span { @include typography('font-weight', 'bold') }
+span { @include typography('font-style', 'italic') }
+```
+
+### get-font-definition function
+
+Returns a font definiton map from a specific viewport
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+$definition: get-font-definition('body', 'md');
+```

--- a/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/readme.md
+++ b/packages/generator-nitro/generators/app/templates/src/shared/utils/typo/readme.md
@@ -25,14 +25,14 @@ Or use a second parameter !== 'all' to only import the definition for specific v
 span { @include typography('h2', 'md') }
 ```
 
-Or use the font-family / font-weight / font-style properties to just get single properties:
+Or use the font-family / font-weight / font-style variables to use the globally defined font properties:
 
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('font-family', 'text') }
-span { @include typography('font-weight', 'bold') }
-span { @include typography('font-style', 'italic') }
+span { font-family: $typography-family-sans; }
+span { font-weight: $typography-weight-bold; }
+span { font-style: $typography-style-italic; }
 ```
 
 ### get-font-definition function

--- a/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
@@ -1,6 +1,6 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-family-sans: Arial, sans-serif;
+$typography-family-sans: 'Arial', sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
 $typography-weight-bold: 700;

--- a/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
@@ -1,98 +1,103 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-default-family: 'minion';
-$typography-default-size: 'm';
+$typography-default-family: 'sans';
+$typography-default-size: 'sans-m';
 $typography-default-style: null;
 
 $typography-normal-ascender: 0.225rem;
 
-$typography-definition-mobile: (
-	sans: (
-		s: (
+$typography-size-definition: (
+	sans-s: (
+		mobile: (
 			'font-size': 17px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
-		m: (
+		desktop: (
+			'font-size': 21px,
+			'line-height': 32px,
+			'letter-spacing': 0.75px
+		)
+	),
+	sans-m: (
+		mobile: (
 			'font-size': 18px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
-		l: (
+		desktop: (
 			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		xl: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		xxl: (
-			'font-size': 26px,
 			'line-height': 32px,
-			'letter-spacing': 0.3px
-		),
-		xxxl: (
-			'font-size': 32px,
-			'line-height': 40px,
 			'letter-spacing': 0.5px
 		)
 	),
-	serif: (
-		s: (
-			'font-size': 14px,
-			'line-height': 20px,
-			'letter-spacing': 0.3px
-		),
-		m: (
-			'font-size': 16px,
-			'line-height': 24px,
-			'letter-spacing': 0.3px
-		),
-	)
-);
-
-$typography-definition-desktop: (
-	sans: (
-		s: (
-			'font-size': 21px,
-			'line-height': 32px,
-			'letter-spacing': 0.75px
-		),
-		m: (
+	sans-l: (
+		mobile: (
 			'font-size': 22px,
-			'line-height': 32px,
-			'letter-spacing': 0.5px
+			'line-height': 28px,
+			'letter-spacing': 0.3px
 		),
-		l: (
+		desktop: (
 			'font-size': 26px,
 			'line-height': 32px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xl: (
+		mobile: (
+			'font-size': 22px,
+			'line-height': 28px,
+			'letter-spacing': 0.3px
 		),
-		xl: (
+		desktop: (
 			'font-size': 26px,
 			'line-height': 36px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xxl: (
+		mobile: (
+			'font-size': 26px,
+			'line-height': 32px,
+			'letter-spacing': 0.3px
 		),
-		xxl: (
+		desktop: (
 			'font-size': 34px,
 			'line-height': 44px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xxxl: (
+		mobile: (
+			'font-size': 32px,
+			'line-height': 40px,
+			'letter-spacing': 0.5px
 		),
-		xxxl: (
+		desktop: (
 			'font-size': 50px,
 			'line-height': 64px,
 			'letter-spacing': 1px
 		)
 	),
-	serif: (
-		s: (
+	serif-s: (
+		mobile: (
 			'font-size': 14px,
 			'line-height': 20px,
 			'letter-spacing': 0.3px
 		),
-		m: (
+		desktop: (
+			'font-size': 14px,
+			'line-height': 20px,
+			'letter-spacing': 0.3px
+		)
+	),
+	serif-m: (
+		mobile: (
+			'font-size': 16px,
+			'line-height': 24px,
+			'letter-spacing': 0.3px
+		),
+		desktop: (
 			'font-size': 16px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
@@ -100,34 +105,15 @@ $typography-definition-desktop: (
 	)
 );
 
+$typography-definition-mobile: ();
+
+$typography-definition-desktop: ();
+
 /*
 	Functions to get the definition
 */
 
-@function typography-get-definition($breakpoint) {
-	@if ($breakpoint == 'mobile') {
-		@return $typography-definition-mobile;
-	}
-	@if ($breakpoint == 'desktop') {
-		@return $typography-definition-desktop;
-	}
-	@warn 'Unknown typography breakpoint '#{$breakpoint}'.';
-}
-
-@function typography-get-font-definition($breakpoint, $size, $family) {
-	$typography-breakpoint: typography-get-definition($breakpoint);
-	$typography-family: map-get($typography-breakpoint, $family);
-	@if ($typography-family == null) {
-		@warn 'Unknown typography definition for breakpoint '#{$breakpoint}' and family '#{$family}'.';
-	}
-	$typography-font-definition: map-get($typography-family, $size);
-	@if ($typography-font-definition == null) {
-		@warn 'Unknown typography definition for breakpoint '#{$breakpoint}', family '#{$family}' and size #{$size}.';
-	}
-	@return $typography-font-definition;
-}
-
-@mixin getDefinition($font-definition, $style, $family) {
+@mixin generate-font-styles($font-definition, $family, $style) {
 	font-size: map-get($font-definition, 'font-size');
 	line-height: map-get($font-definition, 'line-height');
 	letter-spacing: map-get($font-definition, 'letter-spacing');
@@ -145,34 +131,45 @@ $typography-definition-desktop: (
 		}
 	}
 	@if($family == 'serif') {
-		font-family: Arial, sans-serif;
+		font-family: 'Times New Roman', serif;
 
-		@if ($style == 'serif') {
-			font-family: Arial, sans-serif;
+		@if ($style == 'bold') {
+			font-family: 'Times New Roman', serif;
+			font-weight: bold;
 		}
-		@if ($style == 'semi-bold') {
-			font-family: Arial, sans-serif;
+		@if ($style == 'italic') {
+			font-family: 'Times New Roman', serif;
+			font-style: italic;
 		}
 	}
+}
+
+// Return the font definition for the given viewport and font-name
+@function get-font-definition($fontSize, $viewport) {
+	@if (not(map-has-key($typography-size-definition, $fontSize))) {
+		@error 'Typography font name `#{$fontSize}` does not exist.';
+	} @else if (not(map-has-key(map-get($typography-size-definition, $fontSize), $viewport))) {
+		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$fontSize}`.';
+	}
+
+	$font-definition: map-get(map-get($typography-size-definition, $fontSize), $viewport);
+
+	@return $font-definition;
 }
 
 /*
 	mixin to use in the code
 
 	Params:
-		- $size: gets the typo definition according to the size (e.g. s, m, l)
-		- $style: defines the style of the font. Accepted Values are 'bold', 'italic', 'semi-bold'. Default is null
-		- $family: defines the family of the language. Currently is minion default.
-		- $margin-bottom: adds a calculated margin at the bottom.
+		- $size: gets the typo definition according to the size (e.g. sans-s, sans-m, sans-l)
+		- $style: defines the style of the font. Accepted Values are 'bold', 'italic'. Default is null
+		- $family: defines the family of the language. Currently is sans default.
 */
 
-@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, $margin-bottom: 0) {
-
-	$font-definition: typography-get-font-definition('mobile', $size, $family);
-	@include getDefinition($font-definition, $style, $family);
+@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, ) {
+	@include generate-font-styles(get-font-definition($size, 'mobile'), $style, $family);
 
 	@media screen and (min-width: $size-md-min) {
-		$font-definition: typography-get-font-definition('desktop', $size, $family);
-		@include getDefinition($font-definition, $style, $family);
+		@include generate-font-styles(get-font-definition($size, 'desktop'), $style, $family);
 	}
 }

--- a/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
@@ -3,6 +3,9 @@
 $typography-family-sans: Arial, sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
+$typography-weight-bold: 700;
+$typography-style-italic: italic;
+
 $typography-definitions: (
 	default: (
 		base: (
@@ -11,24 +14,6 @@ $typography-definitions: (
 			'font-family': $typography-family-sans,
 			'font-weight': 400,
 			'font-style': normal,
-		),
-	),
-	font-family: (
-		title: (
-			'font-family': $typography-family-sans,
-		),
-		text: (
-			'font-family': $typography-family-sans,
-		),
-	),
-	font-weight: (
-		bold: (
-			'font-weight': 700,
-		),
-	),
-	font-style: (
-		italic: (
-			'font-style': italic,
 		),
 	),
 	body: (
@@ -64,6 +49,7 @@ $typography-definitions: (
 	h1: (
 		all: (
 			'font-family': $typography-family-serif,
+			'font-font-weight': $typography-weight-bold,
 		),
 		mobile: (
 			'font-size': 32px,
@@ -79,6 +65,7 @@ $typography-definitions: (
 	h2: (
 		all: (
 			'font-family': $typography-family-serif,
+			'font-style': $typography-style-italic,
 		),
 		mobile: (
 			'font-size': 24px,
@@ -152,7 +139,7 @@ $typography-definitions: (
 	@if ($viewport == 'all') {
 		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));
 
-		@media screen and (min-width: $size-md-min) {
+		@media (min-width: $size-md-min) {
 			@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'desktop'));
 		}
 	} @else {

--- a/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
@@ -1,13 +1,40 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-default-family: 'sans';
-$typography-default-size: 'sans-m';
-$typography-default-style: null;
-
-$typography-normal-ascender: 0.225rem;
+$typography-family-sans: Arial, sans-serif;
+$typography-family-serif: 'Times New Roman', serif;
 
 $typography-size-definition: (
+	default: (
+		base: (
+			'font-size': 1.6rem,
+			'line-height': 1,
+			'font-family': $typography-family-sans,
+			'font-weight': 400,
+			'font-style': normal,
+		),
+	),
+	font-family: (
+		title: (
+			'font-family': $typography-family-sans,
+		),
+		text: (
+			'font-family': $typography-family-sans,
+		),
+	),
+	font-weight: (
+		bold: (
+			'font-weight': 700,
+		),
+	),
+	font-style: (
+		italic: (
+			'font-style': italic,
+		),
+	),
 	sans-s: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 17px,
 			'line-height': 24px,
@@ -20,6 +47,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-m: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 18px,
 			'line-height': 24px,
@@ -32,6 +62,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-l: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 22px,
 			'line-height': 28px,
@@ -44,6 +77,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 22px,
 			'line-height': 28px,
@@ -56,6 +92,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xxl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 26px,
 			'line-height': 32px,
@@ -68,6 +107,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xxxl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 32px,
 			'line-height': 40px,
@@ -80,6 +122,9 @@ $typography-size-definition: (
 		)
 	),
 	serif-s: (
+		all: (
+			'font-family': $typography-family-serif,
+		),
 		mobile: (
 			'font-size': 14px,
 			'line-height': 20px,
@@ -92,6 +137,9 @@ $typography-size-definition: (
 		)
 	),
 	serif-m: (
+		all: (
+			'font-family': $typography-family-serif,
+		),
 		mobile: (
 			'font-size': 16px,
 			'line-height': 24px,
@@ -105,71 +153,57 @@ $typography-size-definition: (
 	)
 );
 
-$typography-definition-mobile: ();
+// Output generation for font-size definition
+@mixin _generate-font-size($font-size-definition) {
+	font-size: map-get($font-size-definition, 'font-size');
+	line-height: map-get($font-size-definition, 'line-height');
 
-$typography-definition-desktop: ();
-
-/*
-	Functions to get the definition
-*/
-
-@mixin generate-font-styles($font-definition, $family, $style) {
-	font-size: map-get($font-definition, 'font-size');
-	line-height: map-get($font-definition, 'line-height');
-	letter-spacing: map-get($font-definition, 'letter-spacing');
-
-	@if($family == 'sans') {
-		font-family: Arial, sans-serif;
-
-		@if ($style == 'bold') {
-			font-family: Arial, sans-serif;
-			font-weight: bold;
-		}
-		@if ($style == 'italic') {
-			font-family: Arial, sans-serif;
-			font-style: italic;
-		}
+	@if (map-has-key($font-size-definition, 'font-family')) {
+		font-family: map-get($font-size-definition, 'font-family');
 	}
-	@if($family == 'serif') {
-		font-family: 'Times New Roman', serif;
-
-		@if ($style == 'bold') {
-			font-family: 'Times New Roman', serif;
-			font-weight: bold;
-		}
-		@if ($style == 'italic') {
-			font-family: 'Times New Roman', serif;
-			font-style: italic;
-		}
+	@if (map-has-key($font-size-definition, 'font-weight')) {
+		font-weight: map-get($font-size-definition, 'font-weight');
+	}
+	@if (map-has-key($font-size-definition, 'font-style')) {
+		font-style: map-get($font-size-definition, 'font-style');
+	}
+	@if (map-has-key($font-size-definition, 'letter-spacing')) {
+		letter-spacing: map-get($font-size-definition, 'letter-spacing');
+	}
+	@if (map-has-key($font-size-definition, 'text-transform')) {
+		text-transform: map-get($font-size-definition, 'text-transform');
 	}
 }
 
 // Return the font definition for the given viewport and font-name
-@function get-font-definition($fontSize, $viewport) {
-	@if (not(map-has-key($typography-size-definition, $fontSize))) {
-		@error 'Typography font name `#{$fontSize}` does not exist.';
-	} @else if (not(map-has-key(map-get($typography-size-definition, $fontSize), $viewport))) {
-		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$fontSize}`.';
+@function get-font-definition($font-bundle, $viewport) {
+	@if (not(map-has-key($typography-size-definition, $font-bundle))) {
+		@error 'Typography font name `#{$font-bundle}` does not exist.';
+	} @else if (not(map-has-key(map-get($typography-size-definition, $font-bundle), $viewport))) {
+		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$font-bundle}`.';
 	}
 
-	$font-definition: map-get(map-get($typography-size-definition, $fontSize), $viewport);
+	$all-font-definition: ();
+	@if (map-has-key(map-get($typography-size-definition, $font-bundle), 'all')) {
+		$all-font-definition: map-get(map-get($typography-size-definition, $font-bundle), 'all');
+	}
+	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-size-definition, $font-bundle), $viewport));
 
 	@return $font-definition;
 }
 
-/*
-	mixin to use in the code
+// Returns a (responsive) typography for the given font name
+// Usage:
+// span { @include typography('body') }
+// span { @include typography('body', 'md') }
+@mixin typography($font-bundle, $viewport: 'all') {
+	@if ($viewport == 'all') {
+		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));
 
-	Params:
-		- $size: gets the typo definition according to the size (e.g. sans-s, sans-m, sans-l)
-		- $style: defines the style of the font. Accepted Values are 'bold', 'italic'. Default is null
-		- $family: defines the family of the language. Currently is sans default.
-*/
-
-@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, ) {
-	@include generate-font-styles(get-font-definition($size, 'mobile'), $style, $family);
-
-	@media screen and (min-width: $size-md-min) {
-		@include generate-font-styles(get-font-definition($size, 'desktop'), $style, $family);
+		@media screen and (min-width: $size-md-min) {
+			@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'desktop'));
+		}
+	} @else {
+		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: $viewport));
 	}
 }

--- a/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-twig/src/shared/utils/typo/css/typo.scss
@@ -3,7 +3,7 @@
 $typography-family-sans: Arial, sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
-$typography-size-definition: (
+$typography-definitions: (
 	default: (
 		base: (
 			'font-size': 1.6rem,
@@ -31,126 +31,81 @@ $typography-size-definition: (
 			'font-style': italic,
 		),
 	),
-	sans-s: (
+	body: (
 		all: (
 			'font-family': $typography-family-sans,
 		),
 		mobile: (
-			'font-size': 17px,
+			'font-size': 16px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 21px,
+			'font-size': 24px,
 			'line-height': 32px,
 			'letter-spacing': 0.75px
 		)
 	),
-	sans-m: (
+	body-small: (
 		all: (
 			'font-family': $typography-family-sans,
 		),
 		mobile: (
-			'font-size': 18px,
+			'font-size': 12px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 22px,
+			'font-size': 18px,
 			'line-height': 32px,
-			'letter-spacing': 0.5px
+			'letter-spacing': 0.75px
 		)
 	),
-	sans-l: (
+	h1: (
 		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 26px,
-			'line-height': 32px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xl: (
-		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 26px,
-			'line-height': 36px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xxl: (
-		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 26px,
-			'line-height': 32px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 34px,
-			'line-height': 44px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xxxl: (
-		all: (
-			'font-family': $typography-family-sans,
+			'font-family': $typography-family-serif,
 		),
 		mobile: (
 			'font-size': 32px,
-			'line-height': 40px,
-			'letter-spacing': 0.5px
+			'line-height': 44px,
+			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 50px,
-			'line-height': 64px,
-			'letter-spacing': 1px
+			'font-size': 44px,
+			'line-height': 56px,
+			'letter-spacing': 0.3px
 		)
 	),
-	serif-s: (
+	h2: (
 		all: (
 			'font-family': $typography-family-serif,
 		),
 		mobile: (
-			'font-size': 14px,
-			'line-height': 20px,
+			'font-size': 24px,
+			'line-height': 32px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 14px,
-			'line-height': 20px,
+			'font-size': 32px,
+			'line-height': 44px,
 			'letter-spacing': 0.3px
 		)
 	),
-	serif-m: (
+	button: (
 		all: (
 			'font-family': $typography-family-serif,
 		),
 		mobile: (
-			'font-size': 16px,
-			'line-height': 24px,
+			'font-size': 18px,
+			'line-height': 18px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 16px,
-			'line-height': 24px,
+			'font-size': 20px,
+			'line-height': 20px,
 			'letter-spacing': 0.3px
 		)
-	)
+	),
 );
 
 // Output generation for font-size definition
@@ -177,25 +132,22 @@ $typography-size-definition: (
 
 // Return the font definition for the given viewport and font-name
 @function get-font-definition($font-bundle, $viewport) {
-	@if (not(map-has-key($typography-size-definition, $font-bundle))) {
+	@if (not(map-has-key($typography-definitions, $font-bundle))) {
 		@error 'Typography font name `#{$font-bundle}` does not exist.';
-	} @else if (not(map-has-key(map-get($typography-size-definition, $font-bundle), $viewport))) {
+	} @else if (not(map-has-key(map-get($typography-definitions, $font-bundle), $viewport))) {
 		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$font-bundle}`.';
 	}
 
 	$all-font-definition: ();
-	@if (map-has-key(map-get($typography-size-definition, $font-bundle), 'all')) {
-		$all-font-definition: map-get(map-get($typography-size-definition, $font-bundle), 'all');
+	@if (map-has-key(map-get($typography-definitions, $font-bundle), 'all')) {
+		$all-font-definition: map-get(map-get($typography-definitions, $font-bundle), 'all');
 	}
-	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-size-definition, $font-bundle), $viewport));
+	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-definitions, $font-bundle), $viewport));
 
 	@return $font-definition;
 }
 
-// Returns a (responsive) typography for the given font name
-// Usage:
-// span { @include typography('body') }
-// span { @include typography('body', 'md') }
+// Render a set of typography styles for one or all defined viewports
 @mixin typography($font-bundle, $viewport: 'all') {
 	@if ($viewport == 'all') {
 		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));

--- a/packages/project-nitro-twig/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro-twig/src/shared/utils/typo/readme.md
@@ -1,8 +1,10 @@
 # Typo
 
-> Typography util
+> Typography util which returns a set of typography styles for one or all defined viewports 
 
 ## Usage
+
+Please note: depending on the number of viewports, the output bundle size might get a bit large!
 
 ### typography mixin
 
@@ -11,8 +13,8 @@ Writes desired typography definition.
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('sans-s') }
-span { @include typography('serif-m') }
+span { @include typography('body') }
+span { @include typography('h1') }
 ```
 
 Or use a second parameter !== 'all' to only import the definition for specific viewport:
@@ -20,7 +22,7 @@ Or use a second parameter !== 'all' to only import the definition for specific v
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('sans-s', 'md') }
+span { @include typography('h2', 'md') }
 ```
 
 Or use the font-family / font-weight / font-style properties to just get single properties:
@@ -35,7 +37,7 @@ span { @include typography('font-style', 'italic') }
 
 ### get-font-definition function
 
-Returns a font definiton map from a specific viewport
+Returns a font definition map from a specific viewport
 
 ```
 @import 'src/shared/utils/typo/css/typo';

--- a/packages/project-nitro-twig/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro-twig/src/shared/utils/typo/readme.md
@@ -1,0 +1,44 @@
+# Typo
+
+> Typography util
+
+## Usage
+
+### typography mixin
+
+Writes desired typography definition.
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('sans-s') }
+span { @include typography('serif-m') }
+```
+
+Or use a second parameter !== 'all' to only import the definition for specific viewport:
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('sans-s', 'md') }
+```
+
+Or use the font-family / font-weight / font-style properties to just get single properties:
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('font-family', 'text') }
+span { @include typography('font-weight', 'bold') }
+span { @include typography('font-style', 'italic') }
+```
+
+### get-font-definition function
+
+Returns a font definiton map from a specific viewport
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+$definition: get-font-definition('body', 'md');
+```

--- a/packages/project-nitro-twig/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro-twig/src/shared/utils/typo/readme.md
@@ -25,14 +25,14 @@ Or use a second parameter !== 'all' to only import the definition for specific v
 span { @include typography('h2', 'md') }
 ```
 
-Or use the font-family / font-weight / font-style properties to just get single properties:
+Or use the font-family / font-weight / font-style variables to use the globally defined font properties:
 
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('font-family', 'text') }
-span { @include typography('font-weight', 'bold') }
-span { @include typography('font-style', 'italic') }
+span { font-family: $typography-family-sans; }
+span { font-weight: $typography-weight-bold; }
+span { font-style: $typography-style-italic; }
 ```
 
 ### get-font-definition function

--- a/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
@@ -1,6 +1,6 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-family-sans: Arial, sans-serif;
+$typography-family-sans: 'Arial', sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
 $typography-weight-bold: 700;

--- a/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
@@ -1,98 +1,103 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-default-family: 'minion';
-$typography-default-size: 'm';
+$typography-default-family: 'sans';
+$typography-default-size: 'sans-m';
 $typography-default-style: null;
 
 $typography-normal-ascender: 0.225rem;
 
-$typography-definition-mobile: (
-	sans: (
-		s: (
+$typography-size-definition: (
+	sans-s: (
+		mobile: (
 			'font-size': 17px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
-		m: (
+		desktop: (
+			'font-size': 21px,
+			'line-height': 32px,
+			'letter-spacing': 0.75px
+		)
+	),
+	sans-m: (
+		mobile: (
 			'font-size': 18px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
-		l: (
+		desktop: (
 			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		xl: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		xxl: (
-			'font-size': 26px,
 			'line-height': 32px,
-			'letter-spacing': 0.3px
-		),
-		xxxl: (
-			'font-size': 32px,
-			'line-height': 40px,
 			'letter-spacing': 0.5px
 		)
 	),
-	serif: (
-		s: (
-			'font-size': 14px,
-			'line-height': 20px,
-			'letter-spacing': 0.3px
-		),
-		m: (
-			'font-size': 16px,
-			'line-height': 24px,
-			'letter-spacing': 0.3px
-		),
-	)
-);
-
-$typography-definition-desktop: (
-	sans: (
-		s: (
-			'font-size': 21px,
-			'line-height': 32px,
-			'letter-spacing': 0.75px
-		),
-		m: (
+	sans-l: (
+		mobile: (
 			'font-size': 22px,
-			'line-height': 32px,
-			'letter-spacing': 0.5px
+			'line-height': 28px,
+			'letter-spacing': 0.3px
 		),
-		l: (
+		desktop: (
 			'font-size': 26px,
 			'line-height': 32px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xl: (
+		mobile: (
+			'font-size': 22px,
+			'line-height': 28px,
+			'letter-spacing': 0.3px
 		),
-		xl: (
+		desktop: (
 			'font-size': 26px,
 			'line-height': 36px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xxl: (
+		mobile: (
+			'font-size': 26px,
+			'line-height': 32px,
+			'letter-spacing': 0.3px
 		),
-		xxl: (
+		desktop: (
 			'font-size': 34px,
 			'line-height': 44px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xxxl: (
+		mobile: (
+			'font-size': 32px,
+			'line-height': 40px,
+			'letter-spacing': 0.5px
 		),
-		xxxl: (
+		desktop: (
 			'font-size': 50px,
 			'line-height': 64px,
 			'letter-spacing': 1px
 		)
 	),
-	serif: (
-		s: (
+	serif-s: (
+		mobile: (
 			'font-size': 14px,
 			'line-height': 20px,
 			'letter-spacing': 0.3px
 		),
-		m: (
+		desktop: (
+			'font-size': 14px,
+			'line-height': 20px,
+			'letter-spacing': 0.3px
+		)
+	),
+	serif-m: (
+		mobile: (
+			'font-size': 16px,
+			'line-height': 24px,
+			'letter-spacing': 0.3px
+		),
+		desktop: (
 			'font-size': 16px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
@@ -100,34 +105,15 @@ $typography-definition-desktop: (
 	)
 );
 
+$typography-definition-mobile: ();
+
+$typography-definition-desktop: ();
+
 /*
 	Functions to get the definition
 */
 
-@function typography-get-definition($breakpoint) {
-	@if ($breakpoint == 'mobile') {
-		@return $typography-definition-mobile;
-	}
-	@if ($breakpoint == 'desktop') {
-		@return $typography-definition-desktop;
-	}
-	@warn 'Unknown typography breakpoint '#{$breakpoint}'.';
-}
-
-@function typography-get-font-definition($breakpoint, $size, $family) {
-	$typography-breakpoint: typography-get-definition($breakpoint);
-	$typography-family: map-get($typography-breakpoint, $family);
-	@if ($typography-family == null) {
-		@warn 'Unknown typography definition for breakpoint '#{$breakpoint}' and family '#{$family}'.';
-	}
-	$typography-font-definition: map-get($typography-family, $size);
-	@if ($typography-font-definition == null) {
-		@warn 'Unknown typography definition for breakpoint '#{$breakpoint}', family '#{$family}' and size #{$size}.';
-	}
-	@return $typography-font-definition;
-}
-
-@mixin getDefinition($font-definition, $style, $family) {
+@mixin generate-font-styles($font-definition, $family, $style) {
 	font-size: map-get($font-definition, 'font-size');
 	line-height: map-get($font-definition, 'line-height');
 	letter-spacing: map-get($font-definition, 'letter-spacing');
@@ -145,34 +131,45 @@ $typography-definition-desktop: (
 		}
 	}
 	@if($family == 'serif') {
-		font-family: Arial, sans-serif;
+		font-family: 'Times New Roman', serif;
 
-		@if ($style == 'serif') {
-			font-family: Arial, sans-serif;
+		@if ($style == 'bold') {
+			font-family: 'Times New Roman', serif;
+			font-weight: bold;
 		}
-		@if ($style == 'semi-bold') {
-			font-family: Arial, sans-serif;
+		@if ($style == 'italic') {
+			font-family: 'Times New Roman', serif;
+			font-style: italic;
 		}
 	}
+}
+
+// Return the font definition for the given viewport and font-name
+@function get-font-definition($fontSize, $viewport) {
+	@if (not(map-has-key($typography-size-definition, $fontSize))) {
+		@error 'Typography font name `#{$fontSize}` does not exist.';
+	} @else if (not(map-has-key(map-get($typography-size-definition, $fontSize), $viewport))) {
+		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$fontSize}`.';
+	}
+
+	$font-definition: map-get(map-get($typography-size-definition, $fontSize), $viewport);
+
+	@return $font-definition;
 }
 
 /*
 	mixin to use in the code
 
 	Params:
-		- $size: gets the typo definition according to the size (e.g. s, m, l)
-		- $style: defines the style of the font. Accepted Values are 'bold', 'italic', 'semi-bold'. Default is null
-		- $family: defines the family of the language. Currently is minion default.
-		- $margin-bottom: adds a calculated margin at the bottom.
+		- $size: gets the typo definition according to the size (e.g. sans-s, sans-m, sans-l)
+		- $style: defines the style of the font. Accepted Values are 'bold', 'italic'. Default is null
+		- $family: defines the family of the language. Currently is sans default.
 */
 
-@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, $margin-bottom: 0) {
-
-	$font-definition: typography-get-font-definition('mobile', $size, $family);
-	@include getDefinition($font-definition, $style, $family);
+@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, ) {
+	@include generate-font-styles(get-font-definition($size, 'mobile'), $style, $family);
 
 	@media screen and (min-width: $size-md-min) {
-		$font-definition: typography-get-font-definition('desktop', $size, $family);
-		@include getDefinition($font-definition, $style, $family);
+		@include generate-font-styles(get-font-definition($size, 'desktop'), $style, $family);
 	}
 }

--- a/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
@@ -3,6 +3,9 @@
 $typography-family-sans: Arial, sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
+$typography-weight-bold: 700;
+$typography-style-italic: italic;
+
 $typography-definitions: (
 	default: (
 		base: (
@@ -11,24 +14,6 @@ $typography-definitions: (
 			'font-family': $typography-family-sans,
 			'font-weight': 400,
 			'font-style': normal,
-		),
-	),
-	font-family: (
-		title: (
-			'font-family': $typography-family-sans,
-		),
-		text: (
-			'font-family': $typography-family-sans,
-		),
-	),
-	font-weight: (
-		bold: (
-			'font-weight': 700,
-		),
-	),
-	font-style: (
-		italic: (
-			'font-style': italic,
 		),
 	),
 	body: (
@@ -64,6 +49,7 @@ $typography-definitions: (
 	h1: (
 		all: (
 			'font-family': $typography-family-serif,
+			'font-font-weight': $typography-weight-bold,
 		),
 		mobile: (
 			'font-size': 32px,
@@ -79,6 +65,7 @@ $typography-definitions: (
 	h2: (
 		all: (
 			'font-family': $typography-family-serif,
+			'font-style': $typography-style-italic,
 		),
 		mobile: (
 			'font-size': 24px,
@@ -152,7 +139,7 @@ $typography-definitions: (
 	@if ($viewport == 'all') {
 		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));
 
-		@media screen and (min-width: $size-md-min) {
+		@media (min-width: $size-md-min) {
 			@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'desktop'));
 		}
 	} @else {

--- a/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
@@ -1,13 +1,40 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-default-family: 'sans';
-$typography-default-size: 'sans-m';
-$typography-default-style: null;
-
-$typography-normal-ascender: 0.225rem;
+$typography-family-sans: Arial, sans-serif;
+$typography-family-serif: 'Times New Roman', serif;
 
 $typography-size-definition: (
+	default: (
+		base: (
+			'font-size': 1.6rem,
+			'line-height': 1,
+			'font-family': $typography-family-sans,
+			'font-weight': 400,
+			'font-style': normal,
+		),
+	),
+	font-family: (
+		title: (
+			'font-family': $typography-family-sans,
+		),
+		text: (
+			'font-family': $typography-family-sans,
+		),
+	),
+	font-weight: (
+		bold: (
+			'font-weight': 700,
+		),
+	),
+	font-style: (
+		italic: (
+			'font-style': italic,
+		),
+	),
 	sans-s: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 17px,
 			'line-height': 24px,
@@ -20,6 +47,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-m: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 18px,
 			'line-height': 24px,
@@ -32,6 +62,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-l: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 22px,
 			'line-height': 28px,
@@ -44,6 +77,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 22px,
 			'line-height': 28px,
@@ -56,6 +92,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xxl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 26px,
 			'line-height': 32px,
@@ -68,6 +107,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xxxl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 32px,
 			'line-height': 40px,
@@ -80,6 +122,9 @@ $typography-size-definition: (
 		)
 	),
 	serif-s: (
+		all: (
+			'font-family': $typography-family-serif,
+		),
 		mobile: (
 			'font-size': 14px,
 			'line-height': 20px,
@@ -92,6 +137,9 @@ $typography-size-definition: (
 		)
 	),
 	serif-m: (
+		all: (
+			'font-family': $typography-family-serif,
+		),
 		mobile: (
 			'font-size': 16px,
 			'line-height': 24px,
@@ -105,71 +153,57 @@ $typography-size-definition: (
 	)
 );
 
-$typography-definition-mobile: ();
+// Output generation for font-size definition
+@mixin _generate-font-size($font-size-definition) {
+	font-size: map-get($font-size-definition, 'font-size');
+	line-height: map-get($font-size-definition, 'line-height');
 
-$typography-definition-desktop: ();
-
-/*
-	Functions to get the definition
-*/
-
-@mixin generate-font-styles($font-definition, $family, $style) {
-	font-size: map-get($font-definition, 'font-size');
-	line-height: map-get($font-definition, 'line-height');
-	letter-spacing: map-get($font-definition, 'letter-spacing');
-
-	@if($family == 'sans') {
-		font-family: Arial, sans-serif;
-
-		@if ($style == 'bold') {
-			font-family: Arial, sans-serif;
-			font-weight: bold;
-		}
-		@if ($style == 'italic') {
-			font-family: Arial, sans-serif;
-			font-style: italic;
-		}
+	@if (map-has-key($font-size-definition, 'font-family')) {
+		font-family: map-get($font-size-definition, 'font-family');
 	}
-	@if($family == 'serif') {
-		font-family: 'Times New Roman', serif;
-
-		@if ($style == 'bold') {
-			font-family: 'Times New Roman', serif;
-			font-weight: bold;
-		}
-		@if ($style == 'italic') {
-			font-family: 'Times New Roman', serif;
-			font-style: italic;
-		}
+	@if (map-has-key($font-size-definition, 'font-weight')) {
+		font-weight: map-get($font-size-definition, 'font-weight');
+	}
+	@if (map-has-key($font-size-definition, 'font-style')) {
+		font-style: map-get($font-size-definition, 'font-style');
+	}
+	@if (map-has-key($font-size-definition, 'letter-spacing')) {
+		letter-spacing: map-get($font-size-definition, 'letter-spacing');
+	}
+	@if (map-has-key($font-size-definition, 'text-transform')) {
+		text-transform: map-get($font-size-definition, 'text-transform');
 	}
 }
 
 // Return the font definition for the given viewport and font-name
-@function get-font-definition($fontSize, $viewport) {
-	@if (not(map-has-key($typography-size-definition, $fontSize))) {
-		@error 'Typography font name `#{$fontSize}` does not exist.';
-	} @else if (not(map-has-key(map-get($typography-size-definition, $fontSize), $viewport))) {
-		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$fontSize}`.';
+@function get-font-definition($font-bundle, $viewport) {
+	@if (not(map-has-key($typography-size-definition, $font-bundle))) {
+		@error 'Typography font name `#{$font-bundle}` does not exist.';
+	} @else if (not(map-has-key(map-get($typography-size-definition, $font-bundle), $viewport))) {
+		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$font-bundle}`.';
 	}
 
-	$font-definition: map-get(map-get($typography-size-definition, $fontSize), $viewport);
+	$all-font-definition: ();
+	@if (map-has-key(map-get($typography-size-definition, $font-bundle), 'all')) {
+		$all-font-definition: map-get(map-get($typography-size-definition, $font-bundle), 'all');
+	}
+	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-size-definition, $font-bundle), $viewport));
 
 	@return $font-definition;
 }
 
-/*
-	mixin to use in the code
+// Returns a (responsive) typography for the given font name
+// Usage:
+// span { @include typography('body') }
+// span { @include typography('body', 'md') }
+@mixin typography($font-bundle, $viewport: 'all') {
+	@if ($viewport == 'all') {
+		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));
 
-	Params:
-		- $size: gets the typo definition according to the size (e.g. sans-s, sans-m, sans-l)
-		- $style: defines the style of the font. Accepted Values are 'bold', 'italic'. Default is null
-		- $family: defines the family of the language. Currently is sans default.
-*/
-
-@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, ) {
-	@include generate-font-styles(get-font-definition($size, 'mobile'), $style, $family);
-
-	@media screen and (min-width: $size-md-min) {
-		@include generate-font-styles(get-font-definition($size, 'desktop'), $style, $family);
+		@media screen and (min-width: $size-md-min) {
+			@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'desktop'));
+		}
+	} @else {
+		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: $viewport));
 	}
 }

--- a/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro-typescript/src/shared/utils/typo/css/typo.scss
@@ -3,7 +3,7 @@
 $typography-family-sans: Arial, sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
-$typography-size-definition: (
+$typography-definitions: (
 	default: (
 		base: (
 			'font-size': 1.6rem,
@@ -31,126 +31,81 @@ $typography-size-definition: (
 			'font-style': italic,
 		),
 	),
-	sans-s: (
+	body: (
 		all: (
 			'font-family': $typography-family-sans,
 		),
 		mobile: (
-			'font-size': 17px,
+			'font-size': 16px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 21px,
+			'font-size': 24px,
 			'line-height': 32px,
 			'letter-spacing': 0.75px
 		)
 	),
-	sans-m: (
+	body-small: (
 		all: (
 			'font-family': $typography-family-sans,
 		),
 		mobile: (
-			'font-size': 18px,
+			'font-size': 12px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 22px,
+			'font-size': 18px,
 			'line-height': 32px,
-			'letter-spacing': 0.5px
+			'letter-spacing': 0.75px
 		)
 	),
-	sans-l: (
+	h1: (
 		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 26px,
-			'line-height': 32px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xl: (
-		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 26px,
-			'line-height': 36px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xxl: (
-		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 26px,
-			'line-height': 32px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 34px,
-			'line-height': 44px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xxxl: (
-		all: (
-			'font-family': $typography-family-sans,
+			'font-family': $typography-family-serif,
 		),
 		mobile: (
 			'font-size': 32px,
-			'line-height': 40px,
-			'letter-spacing': 0.5px
+			'line-height': 44px,
+			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 50px,
-			'line-height': 64px,
-			'letter-spacing': 1px
+			'font-size': 44px,
+			'line-height': 56px,
+			'letter-spacing': 0.3px
 		)
 	),
-	serif-s: (
+	h2: (
 		all: (
 			'font-family': $typography-family-serif,
 		),
 		mobile: (
-			'font-size': 14px,
-			'line-height': 20px,
+			'font-size': 24px,
+			'line-height': 32px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 14px,
-			'line-height': 20px,
+			'font-size': 32px,
+			'line-height': 44px,
 			'letter-spacing': 0.3px
 		)
 	),
-	serif-m: (
+	button: (
 		all: (
 			'font-family': $typography-family-serif,
 		),
 		mobile: (
-			'font-size': 16px,
-			'line-height': 24px,
+			'font-size': 18px,
+			'line-height': 18px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 16px,
-			'line-height': 24px,
+			'font-size': 20px,
+			'line-height': 20px,
 			'letter-spacing': 0.3px
 		)
-	)
+	),
 );
 
 // Output generation for font-size definition
@@ -177,25 +132,22 @@ $typography-size-definition: (
 
 // Return the font definition for the given viewport and font-name
 @function get-font-definition($font-bundle, $viewport) {
-	@if (not(map-has-key($typography-size-definition, $font-bundle))) {
+	@if (not(map-has-key($typography-definitions, $font-bundle))) {
 		@error 'Typography font name `#{$font-bundle}` does not exist.';
-	} @else if (not(map-has-key(map-get($typography-size-definition, $font-bundle), $viewport))) {
+	} @else if (not(map-has-key(map-get($typography-definitions, $font-bundle), $viewport))) {
 		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$font-bundle}`.';
 	}
 
 	$all-font-definition: ();
-	@if (map-has-key(map-get($typography-size-definition, $font-bundle), 'all')) {
-		$all-font-definition: map-get(map-get($typography-size-definition, $font-bundle), 'all');
+	@if (map-has-key(map-get($typography-definitions, $font-bundle), 'all')) {
+		$all-font-definition: map-get(map-get($typography-definitions, $font-bundle), 'all');
 	}
-	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-size-definition, $font-bundle), $viewport));
+	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-definitions, $font-bundle), $viewport));
 
 	@return $font-definition;
 }
 
-// Returns a (responsive) typography for the given font name
-// Usage:
-// span { @include typography('body') }
-// span { @include typography('body', 'md') }
+// Render a set of typography styles for one or all defined viewports
 @mixin typography($font-bundle, $viewport: 'all') {
 	@if ($viewport == 'all') {
 		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));

--- a/packages/project-nitro-typescript/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro-typescript/src/shared/utils/typo/readme.md
@@ -1,8 +1,10 @@
 # Typo
 
-> Typography util
+> Typography util which returns a set of typography styles for one or all defined viewports 
 
 ## Usage
+
+Please note: depending on the number of viewports, the output bundle size might get a bit large!
 
 ### typography mixin
 
@@ -11,8 +13,8 @@ Writes desired typography definition.
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('sans-s') }
-span { @include typography('serif-m') }
+span { @include typography('body') }
+span { @include typography('h1') }
 ```
 
 Or use a second parameter !== 'all' to only import the definition for specific viewport:
@@ -20,7 +22,7 @@ Or use a second parameter !== 'all' to only import the definition for specific v
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('sans-s', 'md') }
+span { @include typography('h2', 'md') }
 ```
 
 Or use the font-family / font-weight / font-style properties to just get single properties:
@@ -35,7 +37,7 @@ span { @include typography('font-style', 'italic') }
 
 ### get-font-definition function
 
-Returns a font definiton map from a specific viewport
+Returns a font definition map from a specific viewport
 
 ```
 @import 'src/shared/utils/typo/css/typo';

--- a/packages/project-nitro-typescript/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro-typescript/src/shared/utils/typo/readme.md
@@ -1,0 +1,44 @@
+# Typo
+
+> Typography util
+
+## Usage
+
+### typography mixin
+
+Writes desired typography definition.
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('sans-s') }
+span { @include typography('serif-m') }
+```
+
+Or use a second parameter !== 'all' to only import the definition for specific viewport:
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('sans-s', 'md') }
+```
+
+Or use the font-family / font-weight / font-style properties to just get single properties:
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('font-family', 'text') }
+span { @include typography('font-weight', 'bold') }
+span { @include typography('font-style', 'italic') }
+```
+
+### get-font-definition function
+
+Returns a font definiton map from a specific viewport
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+$definition: get-font-definition('body', 'md');
+```

--- a/packages/project-nitro-typescript/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro-typescript/src/shared/utils/typo/readme.md
@@ -25,14 +25,14 @@ Or use a second parameter !== 'all' to only import the definition for specific v
 span { @include typography('h2', 'md') }
 ```
 
-Or use the font-family / font-weight / font-style properties to just get single properties:
+Or use the font-family / font-weight / font-style variables to use the globally defined font properties:
 
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('font-family', 'text') }
-span { @include typography('font-weight', 'bold') }
-span { @include typography('font-style', 'italic') }
+span { font-family: $typography-family-sans; }
+span { font-weight: $typography-weight-bold; }
+span { font-style: $typography-style-italic; }
 ```
 
 ### get-font-definition function

--- a/packages/project-nitro/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro/src/shared/utils/typo/css/typo.scss
@@ -1,6 +1,6 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-family-sans: Arial, sans-serif;
+$typography-family-sans: 'Arial', sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
 $typography-weight-bold: 700;

--- a/packages/project-nitro/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro/src/shared/utils/typo/css/typo.scss
@@ -1,98 +1,103 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-default-family: 'minion';
-$typography-default-size: 'm';
+$typography-default-family: 'sans';
+$typography-default-size: 'sans-m';
 $typography-default-style: null;
 
 $typography-normal-ascender: 0.225rem;
 
-$typography-definition-mobile: (
-	sans: (
-		s: (
+$typography-size-definition: (
+	sans-s: (
+		mobile: (
 			'font-size': 17px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
-		m: (
+		desktop: (
+			'font-size': 21px,
+			'line-height': 32px,
+			'letter-spacing': 0.75px
+		)
+	),
+	sans-m: (
+		mobile: (
 			'font-size': 18px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
-		l: (
+		desktop: (
 			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		xl: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		xxl: (
-			'font-size': 26px,
 			'line-height': 32px,
-			'letter-spacing': 0.3px
-		),
-		xxxl: (
-			'font-size': 32px,
-			'line-height': 40px,
 			'letter-spacing': 0.5px
 		)
 	),
-	serif: (
-		s: (
-			'font-size': 14px,
-			'line-height': 20px,
-			'letter-spacing': 0.3px
-		),
-		m: (
-			'font-size': 16px,
-			'line-height': 24px,
-			'letter-spacing': 0.3px
-		),
-	)
-);
-
-$typography-definition-desktop: (
-	sans: (
-		s: (
-			'font-size': 21px,
-			'line-height': 32px,
-			'letter-spacing': 0.75px
-		),
-		m: (
+	sans-l: (
+		mobile: (
 			'font-size': 22px,
-			'line-height': 32px,
-			'letter-spacing': 0.5px
+			'line-height': 28px,
+			'letter-spacing': 0.3px
 		),
-		l: (
+		desktop: (
 			'font-size': 26px,
 			'line-height': 32px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xl: (
+		mobile: (
+			'font-size': 22px,
+			'line-height': 28px,
+			'letter-spacing': 0.3px
 		),
-		xl: (
+		desktop: (
 			'font-size': 26px,
 			'line-height': 36px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xxl: (
+		mobile: (
+			'font-size': 26px,
+			'line-height': 32px,
+			'letter-spacing': 0.3px
 		),
-		xxl: (
+		desktop: (
 			'font-size': 34px,
 			'line-height': 44px,
 			'letter-spacing': 0.5px
+		)
+	),
+	sans-xxxl: (
+		mobile: (
+			'font-size': 32px,
+			'line-height': 40px,
+			'letter-spacing': 0.5px
 		),
-		xxxl: (
+		desktop: (
 			'font-size': 50px,
 			'line-height': 64px,
 			'letter-spacing': 1px
 		)
 	),
-	serif: (
-		s: (
+	serif-s: (
+		mobile: (
 			'font-size': 14px,
 			'line-height': 20px,
 			'letter-spacing': 0.3px
 		),
-		m: (
+		desktop: (
+			'font-size': 14px,
+			'line-height': 20px,
+			'letter-spacing': 0.3px
+		)
+	),
+	serif-m: (
+		mobile: (
+			'font-size': 16px,
+			'line-height': 24px,
+			'letter-spacing': 0.3px
+		),
+		desktop: (
 			'font-size': 16px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
@@ -100,34 +105,15 @@ $typography-definition-desktop: (
 	)
 );
 
+$typography-definition-mobile: ();
+
+$typography-definition-desktop: ();
+
 /*
 	Functions to get the definition
 */
 
-@function typography-get-definition($breakpoint) {
-	@if ($breakpoint == 'mobile') {
-		@return $typography-definition-mobile;
-	}
-	@if ($breakpoint == 'desktop') {
-		@return $typography-definition-desktop;
-	}
-	@warn 'Unknown typography breakpoint '#{$breakpoint}'.';
-}
-
-@function typography-get-font-definition($breakpoint, $size, $family) {
-	$typography-breakpoint: typography-get-definition($breakpoint);
-	$typography-family: map-get($typography-breakpoint, $family);
-	@if ($typography-family == null) {
-		@warn 'Unknown typography definition for breakpoint '#{$breakpoint}' and family '#{$family}'.';
-	}
-	$typography-font-definition: map-get($typography-family, $size);
-	@if ($typography-font-definition == null) {
-		@warn 'Unknown typography definition for breakpoint '#{$breakpoint}', family '#{$family}' and size #{$size}.';
-	}
-	@return $typography-font-definition;
-}
-
-@mixin getDefinition($font-definition, $style, $family) {
+@mixin generate-font-styles($font-definition, $family, $style) {
 	font-size: map-get($font-definition, 'font-size');
 	line-height: map-get($font-definition, 'line-height');
 	letter-spacing: map-get($font-definition, 'letter-spacing');
@@ -145,34 +131,45 @@ $typography-definition-desktop: (
 		}
 	}
 	@if($family == 'serif') {
-		font-family: Arial, sans-serif;
+		font-family: 'Times New Roman', serif;
 
-		@if ($style == 'serif') {
-			font-family: Arial, sans-serif;
+		@if ($style == 'bold') {
+			font-family: 'Times New Roman', serif;
+			font-weight: bold;
 		}
-		@if ($style == 'semi-bold') {
-			font-family: Arial, sans-serif;
+		@if ($style == 'italic') {
+			font-family: 'Times New Roman', serif;
+			font-style: italic;
 		}
 	}
+}
+
+// Return the font definition for the given viewport and font-name
+@function get-font-definition($fontSize, $viewport) {
+	@if (not(map-has-key($typography-size-definition, $fontSize))) {
+		@error 'Typography font name `#{$fontSize}` does not exist.';
+	} @else if (not(map-has-key(map-get($typography-size-definition, $fontSize), $viewport))) {
+		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$fontSize}`.';
+	}
+
+	$font-definition: map-get(map-get($typography-size-definition, $fontSize), $viewport);
+
+	@return $font-definition;
 }
 
 /*
 	mixin to use in the code
 
 	Params:
-		- $size: gets the typo definition according to the size (e.g. s, m, l)
-		- $style: defines the style of the font. Accepted Values are 'bold', 'italic', 'semi-bold'. Default is null
-		- $family: defines the family of the language. Currently is minion default.
-		- $margin-bottom: adds a calculated margin at the bottom.
+		- $size: gets the typo definition according to the size (e.g. sans-s, sans-m, sans-l)
+		- $style: defines the style of the font. Accepted Values are 'bold', 'italic'. Default is null
+		- $family: defines the family of the language. Currently is sans default.
 */
 
-@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, $margin-bottom: 0) {
-
-	$font-definition: typography-get-font-definition('mobile', $size, $family);
-	@include getDefinition($font-definition, $style, $family);
+@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, ) {
+	@include generate-font-styles(get-font-definition($size, 'mobile'), $style, $family);
 
 	@media screen and (min-width: $size-md-min) {
-		$font-definition: typography-get-font-definition('desktop', $size, $family);
-		@include getDefinition($font-definition, $style, $family);
+		@include generate-font-styles(get-font-definition($size, 'desktop'), $style, $family);
 	}
 }

--- a/packages/project-nitro/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro/src/shared/utils/typo/css/typo.scss
@@ -3,6 +3,9 @@
 $typography-family-sans: Arial, sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
+$typography-weight-bold: 700;
+$typography-style-italic: italic;
+
 $typography-definitions: (
 	default: (
 		base: (
@@ -11,24 +14,6 @@ $typography-definitions: (
 			'font-family': $typography-family-sans,
 			'font-weight': 400,
 			'font-style': normal,
-		),
-	),
-	font-family: (
-		title: (
-			'font-family': $typography-family-sans,
-		),
-		text: (
-			'font-family': $typography-family-sans,
-		),
-	),
-	font-weight: (
-		bold: (
-			'font-weight': 700,
-		),
-	),
-	font-style: (
-		italic: (
-			'font-style': italic,
 		),
 	),
 	body: (
@@ -64,6 +49,7 @@ $typography-definitions: (
 	h1: (
 		all: (
 			'font-family': $typography-family-serif,
+			'font-font-weight': $typography-weight-bold,
 		),
 		mobile: (
 			'font-size': 32px,
@@ -79,6 +65,7 @@ $typography-definitions: (
 	h2: (
 		all: (
 			'font-family': $typography-family-serif,
+			'font-style': $typography-style-italic,
 		),
 		mobile: (
 			'font-size': 24px,
@@ -152,7 +139,7 @@ $typography-definitions: (
 	@if ($viewport == 'all') {
 		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));
 
-		@media screen and (min-width: $size-md-min) {
+		@media (min-width: $size-md-min) {
 			@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'desktop'));
 		}
 	} @else {

--- a/packages/project-nitro/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro/src/shared/utils/typo/css/typo.scss
@@ -1,13 +1,40 @@
 @import '../../breakpoints/css/breakpoints';
 
-$typography-default-family: 'sans';
-$typography-default-size: 'sans-m';
-$typography-default-style: null;
-
-$typography-normal-ascender: 0.225rem;
+$typography-family-sans: Arial, sans-serif;
+$typography-family-serif: 'Times New Roman', serif;
 
 $typography-size-definition: (
+	default: (
+		base: (
+			'font-size': 1.6rem,
+			'line-height': 1,
+			'font-family': $typography-family-sans,
+			'font-weight': 400,
+			'font-style': normal,
+		),
+	),
+	font-family: (
+		title: (
+			'font-family': $typography-family-sans,
+		),
+		text: (
+			'font-family': $typography-family-sans,
+		),
+	),
+	font-weight: (
+		bold: (
+			'font-weight': 700,
+		),
+	),
+	font-style: (
+		italic: (
+			'font-style': italic,
+		),
+	),
 	sans-s: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 17px,
 			'line-height': 24px,
@@ -20,6 +47,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-m: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 18px,
 			'line-height': 24px,
@@ -32,6 +62,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-l: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 22px,
 			'line-height': 28px,
@@ -44,6 +77,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 22px,
 			'line-height': 28px,
@@ -56,6 +92,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xxl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 26px,
 			'line-height': 32px,
@@ -68,6 +107,9 @@ $typography-size-definition: (
 		)
 	),
 	sans-xxxl: (
+		all: (
+			'font-family': $typography-family-sans,
+		),
 		mobile: (
 			'font-size': 32px,
 			'line-height': 40px,
@@ -80,6 +122,9 @@ $typography-size-definition: (
 		)
 	),
 	serif-s: (
+		all: (
+			'font-family': $typography-family-serif,
+		),
 		mobile: (
 			'font-size': 14px,
 			'line-height': 20px,
@@ -92,6 +137,9 @@ $typography-size-definition: (
 		)
 	),
 	serif-m: (
+		all: (
+			'font-family': $typography-family-serif,
+		),
 		mobile: (
 			'font-size': 16px,
 			'line-height': 24px,
@@ -105,71 +153,57 @@ $typography-size-definition: (
 	)
 );
 
-$typography-definition-mobile: ();
+// Output generation for font-size definition
+@mixin _generate-font-size($font-size-definition) {
+	font-size: map-get($font-size-definition, 'font-size');
+	line-height: map-get($font-size-definition, 'line-height');
 
-$typography-definition-desktop: ();
-
-/*
-	Functions to get the definition
-*/
-
-@mixin generate-font-styles($font-definition, $family, $style) {
-	font-size: map-get($font-definition, 'font-size');
-	line-height: map-get($font-definition, 'line-height');
-	letter-spacing: map-get($font-definition, 'letter-spacing');
-
-	@if($family == 'sans') {
-		font-family: Arial, sans-serif;
-
-		@if ($style == 'bold') {
-			font-family: Arial, sans-serif;
-			font-weight: bold;
-		}
-		@if ($style == 'italic') {
-			font-family: Arial, sans-serif;
-			font-style: italic;
-		}
+	@if (map-has-key($font-size-definition, 'font-family')) {
+		font-family: map-get($font-size-definition, 'font-family');
 	}
-	@if($family == 'serif') {
-		font-family: 'Times New Roman', serif;
-
-		@if ($style == 'bold') {
-			font-family: 'Times New Roman', serif;
-			font-weight: bold;
-		}
-		@if ($style == 'italic') {
-			font-family: 'Times New Roman', serif;
-			font-style: italic;
-		}
+	@if (map-has-key($font-size-definition, 'font-weight')) {
+		font-weight: map-get($font-size-definition, 'font-weight');
+	}
+	@if (map-has-key($font-size-definition, 'font-style')) {
+		font-style: map-get($font-size-definition, 'font-style');
+	}
+	@if (map-has-key($font-size-definition, 'letter-spacing')) {
+		letter-spacing: map-get($font-size-definition, 'letter-spacing');
+	}
+	@if (map-has-key($font-size-definition, 'text-transform')) {
+		text-transform: map-get($font-size-definition, 'text-transform');
 	}
 }
 
 // Return the font definition for the given viewport and font-name
-@function get-font-definition($fontSize, $viewport) {
-	@if (not(map-has-key($typography-size-definition, $fontSize))) {
-		@error 'Typography font name `#{$fontSize}` does not exist.';
-	} @else if (not(map-has-key(map-get($typography-size-definition, $fontSize), $viewport))) {
-		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$fontSize}`.';
+@function get-font-definition($font-bundle, $viewport) {
+	@if (not(map-has-key($typography-size-definition, $font-bundle))) {
+		@error 'Typography font name `#{$font-bundle}` does not exist.';
+	} @else if (not(map-has-key(map-get($typography-size-definition, $font-bundle), $viewport))) {
+		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$font-bundle}`.';
 	}
 
-	$font-definition: map-get(map-get($typography-size-definition, $fontSize), $viewport);
+	$all-font-definition: ();
+	@if (map-has-key(map-get($typography-size-definition, $font-bundle), 'all')) {
+		$all-font-definition: map-get(map-get($typography-size-definition, $font-bundle), 'all');
+	}
+	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-size-definition, $font-bundle), $viewport));
 
 	@return $font-definition;
 }
 
-/*
-	mixin to use in the code
+// Returns a (responsive) typography for the given font name
+// Usage:
+// span { @include typography('body') }
+// span { @include typography('body', 'md') }
+@mixin typography($font-bundle, $viewport: 'all') {
+	@if ($viewport == 'all') {
+		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));
 
-	Params:
-		- $size: gets the typo definition according to the size (e.g. sans-s, sans-m, sans-l)
-		- $style: defines the style of the font. Accepted Values are 'bold', 'italic'. Default is null
-		- $family: defines the family of the language. Currently is sans default.
-*/
-
-@mixin typography($size: $typography-default-size, $style: $typography-default-style, $family: $typography-default-family, ) {
-	@include generate-font-styles(get-font-definition($size, 'mobile'), $style, $family);
-
-	@media screen and (min-width: $size-md-min) {
-		@include generate-font-styles(get-font-definition($size, 'desktop'), $style, $family);
+		@media screen and (min-width: $size-md-min) {
+			@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'desktop'));
+		}
+	} @else {
+		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: $viewport));
 	}
 }

--- a/packages/project-nitro/src/shared/utils/typo/css/typo.scss
+++ b/packages/project-nitro/src/shared/utils/typo/css/typo.scss
@@ -3,7 +3,7 @@
 $typography-family-sans: Arial, sans-serif;
 $typography-family-serif: 'Times New Roman', serif;
 
-$typography-size-definition: (
+$typography-definitions: (
 	default: (
 		base: (
 			'font-size': 1.6rem,
@@ -31,126 +31,81 @@ $typography-size-definition: (
 			'font-style': italic,
 		),
 	),
-	sans-s: (
+	body: (
 		all: (
 			'font-family': $typography-family-sans,
 		),
 		mobile: (
-			'font-size': 17px,
+			'font-size': 16px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 21px,
+			'font-size': 24px,
 			'line-height': 32px,
 			'letter-spacing': 0.75px
 		)
 	),
-	sans-m: (
+	body-small: (
 		all: (
 			'font-family': $typography-family-sans,
 		),
 		mobile: (
-			'font-size': 18px,
+			'font-size': 12px,
 			'line-height': 24px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 22px,
+			'font-size': 18px,
 			'line-height': 32px,
-			'letter-spacing': 0.5px
+			'letter-spacing': 0.75px
 		)
 	),
-	sans-l: (
+	h1: (
 		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 26px,
-			'line-height': 32px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xl: (
-		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 22px,
-			'line-height': 28px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 26px,
-			'line-height': 36px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xxl: (
-		all: (
-			'font-family': $typography-family-sans,
-		),
-		mobile: (
-			'font-size': 26px,
-			'line-height': 32px,
-			'letter-spacing': 0.3px
-		),
-		desktop: (
-			'font-size': 34px,
-			'line-height': 44px,
-			'letter-spacing': 0.5px
-		)
-	),
-	sans-xxxl: (
-		all: (
-			'font-family': $typography-family-sans,
+			'font-family': $typography-family-serif,
 		),
 		mobile: (
 			'font-size': 32px,
-			'line-height': 40px,
-			'letter-spacing': 0.5px
+			'line-height': 44px,
+			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 50px,
-			'line-height': 64px,
-			'letter-spacing': 1px
+			'font-size': 44px,
+			'line-height': 56px,
+			'letter-spacing': 0.3px
 		)
 	),
-	serif-s: (
+	h2: (
 		all: (
 			'font-family': $typography-family-serif,
 		),
 		mobile: (
-			'font-size': 14px,
-			'line-height': 20px,
+			'font-size': 24px,
+			'line-height': 32px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 14px,
-			'line-height': 20px,
+			'font-size': 32px,
+			'line-height': 44px,
 			'letter-spacing': 0.3px
 		)
 	),
-	serif-m: (
+	button: (
 		all: (
 			'font-family': $typography-family-serif,
 		),
 		mobile: (
-			'font-size': 16px,
-			'line-height': 24px,
+			'font-size': 18px,
+			'line-height': 18px,
 			'letter-spacing': 0.3px
 		),
 		desktop: (
-			'font-size': 16px,
-			'line-height': 24px,
+			'font-size': 20px,
+			'line-height': 20px,
 			'letter-spacing': 0.3px
 		)
-	)
+	),
 );
 
 // Output generation for font-size definition
@@ -177,25 +132,22 @@ $typography-size-definition: (
 
 // Return the font definition for the given viewport and font-name
 @function get-font-definition($font-bundle, $viewport) {
-	@if (not(map-has-key($typography-size-definition, $font-bundle))) {
+	@if (not(map-has-key($typography-definitions, $font-bundle))) {
 		@error 'Typography font name `#{$font-bundle}` does not exist.';
-	} @else if (not(map-has-key(map-get($typography-size-definition, $font-bundle), $viewport))) {
+	} @else if (not(map-has-key(map-get($typography-definitions, $font-bundle), $viewport))) {
 		@error 'Typography viewport size `#{$viewport}` does not exist for font `#{$font-bundle}`.';
 	}
 
 	$all-font-definition: ();
-	@if (map-has-key(map-get($typography-size-definition, $font-bundle), 'all')) {
-		$all-font-definition: map-get(map-get($typography-size-definition, $font-bundle), 'all');
+	@if (map-has-key(map-get($typography-definitions, $font-bundle), 'all')) {
+		$all-font-definition: map-get(map-get($typography-definitions, $font-bundle), 'all');
 	}
-	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-size-definition, $font-bundle), $viewport));
+	$font-definition: map-merge($all-font-definition, map-get(map-get($typography-definitions, $font-bundle), $viewport));
 
 	@return $font-definition;
 }
 
-// Returns a (responsive) typography for the given font name
-// Usage:
-// span { @include typography('body') }
-// span { @include typography('body', 'md') }
+// Render a set of typography styles for one or all defined viewports
 @mixin typography($font-bundle, $viewport: 'all') {
 	@if ($viewport == 'all') {
 		@include _generate-font-size(get-font-definition($font-bundle: $font-bundle, $viewport: 'mobile'));

--- a/packages/project-nitro/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro/src/shared/utils/typo/readme.md
@@ -1,8 +1,10 @@
 # Typo
 
-> Typography util
+> Typography util which returns a set of typography styles for one or all defined viewports 
 
 ## Usage
+
+Please note: depending on the number of viewports, the output bundle size might get a bit large!
 
 ### typography mixin
 
@@ -11,8 +13,8 @@ Writes desired typography definition.
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('sans-s') }
-span { @include typography('serif-m') }
+span { @include typography('body') }
+span { @include typography('h1') }
 ```
 
 Or use a second parameter !== 'all' to only import the definition for specific viewport:
@@ -20,7 +22,7 @@ Or use a second parameter !== 'all' to only import the definition for specific v
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('sans-s', 'md') }
+span { @include typography('h2', 'md') }
 ```
 
 Or use the font-family / font-weight / font-style properties to just get single properties:
@@ -35,7 +37,7 @@ span { @include typography('font-style', 'italic') }
 
 ### get-font-definition function
 
-Returns a font definiton map from a specific viewport
+Returns a font definition map from a specific viewport
 
 ```
 @import 'src/shared/utils/typo/css/typo';

--- a/packages/project-nitro/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro/src/shared/utils/typo/readme.md
@@ -1,0 +1,44 @@
+# Typo
+
+> Typography util
+
+## Usage
+
+### typography mixin
+
+Writes desired typography definition.
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('sans-s') }
+span { @include typography('serif-m') }
+```
+
+Or use a second parameter !== 'all' to only import the definition for specific viewport:
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('sans-s', 'md') }
+```
+
+Or use the font-family / font-weight / font-style properties to just get single properties:
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+span { @include typography('font-family', 'text') }
+span { @include typography('font-weight', 'bold') }
+span { @include typography('font-style', 'italic') }
+```
+
+### get-font-definition function
+
+Returns a font definiton map from a specific viewport
+
+```
+@import 'src/shared/utils/typo/css/typo';
+
+$definition: get-font-definition('body', 'md');
+```

--- a/packages/project-nitro/src/shared/utils/typo/readme.md
+++ b/packages/project-nitro/src/shared/utils/typo/readme.md
@@ -25,14 +25,14 @@ Or use a second parameter !== 'all' to only import the definition for specific v
 span { @include typography('h2', 'md') }
 ```
 
-Or use the font-family / font-weight / font-style properties to just get single properties:
+Or use the font-family / font-weight / font-style variables to use the globally defined font properties:
 
 ```
 @import 'src/shared/utils/typo/css/typo';
 
-span { @include typography('font-family', 'text') }
-span { @include typography('font-weight', 'bold') }
-span { @include typography('font-style', 'italic') }
+span { font-family: $typography-family-sans; }
+span { font-weight: $typography-weight-bold; }
+span { font-style: $typography-style-italic; }
 ```
 
 ### get-font-definition function


### PR DESCRIPTION
## Purpose of this pull request? 

* Enhancement

The pull request refers to the:

* generator (generator-nitro)
* example nitro project (project-nitro)
* example nitro project with twig engine (project-nitro-twig)

## What changes did you make?

Adjusted the typo mixin / typo definitions to have the typo bundle name as first and the viewports as second level. This makes keeping the overview of the different viewports per bundle easier as they are close together
