### PR TITLE
fix(webpack): link resources relative to the css

### DIFF
--- a/packages/generator-nitro/generators/app/templates/config/default/exporter.js
+++ b/packages/generator-nitro/generators/app/templates/config/default/exporter.js
@@ -39,10 +39,6 @@ const config = {
 					glob: ['export/<% if (options.themes) { %>*/<% } %>css/*.css'],
 					replace: [
 						{
-							from: '/assets/<% if (options.themes) { %>(light|dark)/<% } %>',
-							to: '../',
-						},
-						{
 							from: '/content/',
 							to: '../content/',
 						},

--- a/packages/nitro-webpack/webpack-config/webpack.config.dev.js
+++ b/packages/nitro-webpack/webpack-config/webpack.config.dev.js
@@ -132,6 +132,9 @@ module.exports = (options = { rules: {}, features: {} }) => {
 			use: [
 				{
 					loader: MiniCssExtractPlugin.loader,
+					options: {
+						publicPath: '../',
+					},
 				},
 				{
 					loader: require.resolve('css-loader'),

--- a/packages/nitro-webpack/webpack-config/webpack.config.prod.js
+++ b/packages/nitro-webpack/webpack-config/webpack.config.prod.js
@@ -106,7 +106,12 @@ module.exports = (options = { rules: {}, features: {} }) => {
 		webpackConfig.module.rules.push({
 			test: /\.s?css$/,
 			use: [
-				MiniCssExtractPlugin.loader,
+				{
+					loader: MiniCssExtractPlugin.loader,
+					options: {
+						publicPath: '../',
+					},
+				},
 				{
 					loader: require.resolve('css-loader'),
 					options: {

--- a/packages/project-nitro-twig/config/default/exporter.js
+++ b/packages/project-nitro-twig/config/default/exporter.js
@@ -39,10 +39,6 @@ const config = {
 					glob: ['export/css/*.css'],
 					replace: [
 						{
-							from: '/assets/',
-							to: '../',
-						},
-						{
 							from: '/content/',
 							to: '../content/',
 						},

--- a/packages/project-nitro-typescript/config/default/exporter.js
+++ b/packages/project-nitro-typescript/config/default/exporter.js
@@ -39,10 +39,6 @@ const config = {
 					glob: ['export/css/*.css'],
 					replace: [
 						{
-							from: '/assets/',
-							to: '../',
-						},
-						{
 							from: '/content/',
 							to: '../content/',
 						},

--- a/packages/project-nitro/config/default/exporter.js
+++ b/packages/project-nitro/config/default/exporter.js
@@ -39,10 +39,6 @@ const config = {
 					glob: ['export/*/css/*.css'],
 					replace: [
 						{
-							from: '/assets/(light|dark)/',
-							to: '../',
-						},
-						{
 							from: '/content/',
 							to: '../content/',
 						},
@@ -134,10 +130,6 @@ const config = {
 							to: 'content/',
 						},
 						{
-							from: 'example-patterns',
-							to: '404',
-						},
-						{
 							from: ' href="/?([a-z0-9-]+)"',
 							to: ' href="$1.html"',
 						},
@@ -146,10 +138,6 @@ const config = {
 				{
 					glob: ['target/assets/css/*.css'],
 					replace: [
-						{
-							from: '/assets/',
-							to: '../',
-						},
 						{
 							from: '/content/',
 							to: '../content/',


### PR DESCRIPTION
## Purpose of this pull request?

- Enhancement

The pull request refers to the:

- nitro webpack config (@nitro/webpack)
- example nitro projects

## What changes did you make?

Assets in CSS are now relatively linked
